### PR TITLE
refactor(map-backend): standardise APIRouter prefix pattern

### DIFF
--- a/backend/map-backend/domains/elevation_dem_service/api.py
+++ b/backend/map-backend/domains/elevation_dem_service/api.py
@@ -24,7 +24,7 @@ from domains.elevation_dem_service import ports as elevation_ports
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(tags=["elevation-dem"])
+router = APIRouter(prefix="/elevation", tags=["elevation-dem"])
 
 # --- Response cache (bounding box + point signature) ---
 
@@ -94,7 +94,7 @@ def _cache_set(key: tuple, response: ElevationCorrectionResponse) -> None:
             _cache.popitem(last=False)
 
 
-@router.post("/elevation/correct", response_model=ElevationCorrectionResponse)
+@router.post("/correct", response_model=ElevationCorrectionResponse)
 async def correct_elevation_dem(request: ElevationCorrectionRequest) -> ElevationCorrectionResponse:
     """
     Correct ``elevation_m`` using Copernicus GLO-30 DEM tiles (local cache + rasterio).

--- a/backend/map-backend/domains/trails_service/api.py
+++ b/backend/map-backend/domains/trails_service/api.py
@@ -19,10 +19,10 @@ from .queries import RESORT_BBOX_SQL
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(tags=["trails"])
+router = APIRouter(prefix="/trails", tags=["trails"])
 
 
-@router.get("/trails/resort")
+@router.get("/resort")
 async def resort_trails_geojson(
     bbox: str = Query(
         ...,


### PR DESCRIPTION
## Summary
- `trails_service`: moved `/trails` from route decorator into `APIRouter(prefix="/trails")`, route becomes `/resort`
- `elevation_dem_service`: moved `/elevation` from route decorator into `APIRouter(prefix="/elevation")`, route becomes `/correct`
- No URL changes — net effect is zero

All three map-backend routers now follow the same pattern as `activities_service`.
