### PR TITLE
Record the applied rulesets

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -1,0 +1,24 @@
+# Applied rulesets
+
+The JSON in this directory is what was POSTed to the repository rulesets API.
+GitHub does not read these files; they are here so the configuration is
+reviewable in a PR and re-appliable if a ruleset is ever deleted.
+
+Re-apply with:
+
+```bash
+gh api -X POST repos/Syntraksoftware/Snowtrak/rulesets \
+  --input .github/rulesets/protected-branches.json
+gh api -X POST repos/Syntraksoftware/Snowtrak/rulesets \
+  --input .github/rulesets/release-tags.json
+```
+
+Read what is currently live with:
+
+```bash
+gh api repos/Syntraksoftware/Snowtrak/rulesets --jq '.[]|"\(.name) \(.target) \(.enforcement)"'
+```
+
+`release-tags` uses `actor_id: 5`, the built-in `admin` repository role. This
+was verified by pushing a `v*` tag as an admin and getting "Bypassed rule
+violations" rather than a rejection.

--- a/.github/rulesets/protected-branches.json
+++ b/.github/rulesets/protected-branches.json
@@ -1,0 +1,35 @@
+{
+  "name": "protected-branches",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": { "include": ["refs/heads/main", "refs/heads/develop"], "exclude": [] }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      } },
+    { "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "required_status_checks": [
+          { "context": "Backend Tests" },
+          { "context": "Frontend Tests" },
+          { "context": "Lint" },
+          { "context": "Test (main-backend)" },
+          { "context": "Test (community-backend)" },
+          { "context": "Test (activity-backend)" },
+          { "context": "Test (shared)" },
+          { "context": "GitGuardian Security Checks" }
+        ]
+      } }
+  ],
+  "bypass_actors": []
+}

--- a/.github/rulesets/release-tags.json
+++ b/.github/rulesets/release-tags.json
@@ -1,0 +1,16 @@
+{
+  "name": "release-tags",
+  "target": "tag",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": { "include": ["refs/tags/v*"], "exclude": [] }
+  },
+  "rules": [
+    { "type": "creation" },
+    { "type": "update" },
+    { "type": "deletion" }
+  ],
+  "bypass_actors": [
+    { "actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "always" }
+  ]
+}


### PR DESCRIPTION
Implements Task 4 of `DEPLOY_AUTHORIZATION_SPEC.md`. The rulesets are already live; this commits the JSON that was applied so the configuration is reviewable and re-appliable.

## What is now enforced

**`protected-branches`** on `main` + `develop` — no direct pushes, no force-pushes, no deletion, PR required (0 approvals by choice), 8 required checks.

**`release-tags`** on `v*` — only repository admins can create, move or delete a release tag.

## Verified against the live repo, not assumed

- Direct push to `main` → **rejected**: `GH013 ... Changes must be made through a pull request` / `8 of 8 required status checks are expected`
- Admin `v*` tag push → `Bypassed rule violations`, which confirms `actor_id: 5` is the admin role. A non-admin gets the hard rejection instead.
- Probe tag `v0.0.0-probe` triggered **no** iOS release run, confirming the narrowed `v[0-9]+.[0-9]+.[0-9]+` pattern from PR #30 excludes pre-release tags.

## Note on this PR

This is the first PR to pass through the gate it documents. It should be unmergeable until all 8 required checks report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)