### PR TITLE
Deploy the images CI scanned

### DIFF
--- a/.github/workflows/deploy-backend-vps.yml
+++ b/.github/workflows/deploy-backend-vps.yml
@@ -17,9 +17,9 @@ on:
           - staging
           - production
       ref:
-        description: Branch or tag to deploy (staging only; production always deploys main)
-        required: false
-        default: main
+        description: 'Release tag (v1.2.3), or a 40-char commit SHA for staging only'
+        required: true
+        default: ''
         type: string
       action:
         description: Bring the stack up, or take it down (staging only)
@@ -42,6 +42,70 @@ jobs:
     # over the other.
     environment: ${{ inputs.environment }}
     steps:
+      - name: Resolve image digests
+        id: images
+        shell: bash
+        env:
+          REF: ${{ inputs.ref }}
+          DEPLOY_ENV: ${{ inputs.environment }}
+        run: |
+          set -euo pipefail
+
+          # A teardown pulls nothing, but `docker compose down` still parses the
+          # Compose file, and the image variables there are `:?` so that a real
+          # deploy fails loudly rather than running an empty image reference.
+          # Unset them and the teardown aborts instead of the stack coming down.
+          if [ "${{ inputs.action }}" = "down" ]; then
+            for v in SNOWTRAK_MAIN_IMAGE SNOWTRAK_COMMUNITY_IMAGE \
+                     SNOWTRAK_ACTIVITY_IMAGE SNOWTRAK_MAP_IMAGE; do
+              echo "$v=unused-for-teardown" >> "$GITHUB_ENV"
+            done
+            echo "Teardown: image resolution skipped." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # Production takes release tags only. Staging additionally takes a raw
+          # commit SHA so a develop commit can be tested without cutting a tag.
+          if [[ "$REF" =~ ^v ]]; then
+            image_tag="$REF"
+          elif [[ "$REF" =~ ^[0-9a-f]{40}$ ]]; then
+            if [ "$DEPLOY_ENV" = "production" ]; then
+              echo "::error::production deploys a v* release tag, not a raw SHA." >&2
+              exit 1
+            fi
+            image_tag="sha-$REF"
+          else
+            echo "::error::ref must be a v* tag or a 40-character commit SHA, got '$REF'." >&2
+            exit 1
+          fi
+
+          # map-backend is production-only; the staging Compose file has no such
+          # service, so resolving it would fail on an image that is never used.
+          services="main-backend community-backend activity-backend"
+          if [ "$DEPLOY_ENV" = "production" ]; then
+            services="$services map-backend"
+          fi
+
+          echo "Resolving \`$image_tag\`" >> "$GITHUB_STEP_SUMMARY"
+          for svc in $services; do
+            image="ghcr.io/syntraksoftware/snowtrak-${svc}"
+            digest=$(docker buildx imagetools inspect "${image}:${image_tag}" \
+              --format '{{.Manifest.Digest}}')
+            if [ -z "$digest" ]; then
+              echo "::error::could not resolve ${image}:${image_tag}" >&2
+              exit 1
+            fi
+            pinned="${image}@${digest}"
+            echo "- \`${svc}\` -> \`${digest}\`" >> "$GITHUB_STEP_SUMMARY"
+
+            case "$svc" in
+              main-backend)      echo "SNOWTRAK_MAIN_IMAGE=$pinned"      >> "$GITHUB_ENV" ;;
+              community-backend) echo "SNOWTRAK_COMMUNITY_IMAGE=$pinned" >> "$GITHUB_ENV" ;;
+              activity-backend)  echo "SNOWTRAK_ACTIVITY_IMAGE=$pinned"  >> "$GITHUB_ENV" ;;
+              map-backend)       echo "SNOWTRAK_MAP_IMAGE=$pinned"       >> "$GITHUB_ENV" ;;
+            esac
+          done
+
       - name: Reject a production teardown
         if: inputs.environment == 'production' && inputs.action == 'down'
         run: |
@@ -54,11 +118,15 @@ jobs:
           DEPLOY_ENV: ${{ inputs.environment }}
           DEPLOY_REF: ${{ inputs.ref }}
           DEPLOY_ACTION: ${{ inputs.action }}
+          SNOWTRAK_MAIN_IMAGE: ${{ env.SNOWTRAK_MAIN_IMAGE }}
+          SNOWTRAK_COMMUNITY_IMAGE: ${{ env.SNOWTRAK_COMMUNITY_IMAGE }}
+          SNOWTRAK_ACTIVITY_IMAGE: ${{ env.SNOWTRAK_ACTIVITY_IMAGE }}
+          SNOWTRAK_MAP_IMAGE: ${{ env.SNOWTRAK_MAP_IMAGE }}
         with:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
-          envs: DEPLOY_ENV,DEPLOY_REF,DEPLOY_ACTION
+          envs: DEPLOY_ENV,DEPLOY_REF,DEPLOY_ACTION,SNOWTRAK_MAIN_IMAGE,SNOWTRAK_COMMUNITY_IMAGE,SNOWTRAK_ACTIVITY_IMAGE,SNOWTRAK_MAP_IMAGE
           script: |
             set -euo pipefail
             cd "${{ secrets.VPS_APP_DIR }}"
@@ -102,7 +170,10 @@ jobs:
             git checkout --detach "origin/$REF" 2>/dev/null || git checkout --detach "$REF"
             echo "Deploying $DEPLOY_ENV from $REF at $(git rev-parse --short HEAD)"
 
-            docker compose -f "$COMPOSE" -p "$PROJECT" up -d --build
+            # Pull the exact digests CI scanned. The box no longer builds: the
+            # image that Trivy passed is the image that runs.
+            docker compose -f "$COMPOSE" -p "$PROJECT" pull
+            docker compose -f "$COMPOSE" -p "$PROJECT" up -d
             docker image prune -f
 
             # Compose returns as soon as the containers start, which is before

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -3,6 +3,9 @@ name: Docker Images
 on:
   push:
     branches: [main, develop, restructure]
+    # Release tags publish too. Without this a v1.2.3 tag builds nothing, and
+    # the deploy workflow's digest lookup has no image to find.
+    tags: ['v*']
   pull_request:
     branches: [main, develop, restructure]
   workflow_dispatch:

--- a/backend/deploy/docker-compose.production.yml
+++ b/backend/deploy/docker-compose.production.yml
@@ -11,9 +11,7 @@ services:
     restart: unless-stopped
 
   main-backend:
-    build:
-      context: ../
-      dockerfile: ./main-backend/Dockerfile
+    image: ${SNOWTRAK_MAIN_IMAGE:?set by the deploy workflow to a pinned digest}
     env_file:
       - ../main-backend/.env
     environment:
@@ -36,9 +34,7 @@ services:
       - redis
 
   community-backend:
-    build:
-      context: ../
-      dockerfile: ./community-backend/Dockerfile
+    image: ${SNOWTRAK_COMMUNITY_IMAGE:?set by the deploy workflow to a pinned digest}
     env_file:
       - ../community-backend/.env
     environment:
@@ -61,9 +57,7 @@ services:
       - redis
 
   activity-backend:
-    build:
-      context: ../
-      dockerfile: ./activity-backend/Dockerfile
+    image: ${SNOWTRAK_ACTIVITY_IMAGE:?set by the deploy workflow to a pinned digest}
     env_file:
       - ../activity-backend/.env
     environment:
@@ -84,9 +78,7 @@ services:
       - redis
 
   map-backend:
-    build:
-      context: ../
-      dockerfile: ./map-backend/Dockerfile
+    image: ${SNOWTRAK_MAP_IMAGE:?set by the deploy workflow to a pinned digest}
     env_file:
       - ../map-backend/.env
     environment:

--- a/backend/deploy/docker-compose.staging.yml
+++ b/backend/deploy/docker-compose.staging.yml
@@ -11,9 +11,7 @@ services:
     restart: unless-stopped
 
   main-backend:
-    build:
-      context: ../
-      dockerfile: ./main-backend/Dockerfile
+    image: ${SNOWTRAK_MAIN_IMAGE:?set by the deploy workflow to a pinned digest}
     env_file:
       - ../main-backend/.env
     environment:
@@ -36,9 +34,7 @@ services:
       - redis
 
   community-backend:
-    build:
-      context: ../
-      dockerfile: ./community-backend/Dockerfile
+    image: ${SNOWTRAK_COMMUNITY_IMAGE:?set by the deploy workflow to a pinned digest}
     env_file:
       - ../community-backend/.env
     environment:
@@ -61,9 +57,7 @@ services:
       - redis
 
   activity-backend:
-    build:
-      context: ../
-      dockerfile: ./activity-backend/Dockerfile
+    image: ${SNOWTRAK_ACTIVITY_IMAGE:?set by the deploy workflow to a pinned digest}
     env_file:
       - ../activity-backend/.env
     environment:


### PR DESCRIPTION
Implements Tasks 5-7 of `DEPLOY_AUTHORIZATION_SPEC.md`.

## The problem

The VPS built its own images with `up -d --build`, so the bytes Trivy passed and the bytes production ran were never the same artifact.

Worth correcting a claim in the original spec: CI **has** been publishing scanned images to GHCR all along (login + push run after the Trivy gate, verified on run `32045435488`). The `push: false` in that workflow is the scan-time local build. So the gap was never on the publishing side; nothing *consumed* the images.

## Changes

**`docker-images.yml`** - one line. It fired on branches only, so a `v1.2.3` tag published nothing for the deploy to find. No naming change was needed: the existing step reads `GITHUB_REF_NAME`, which on a tag push is the tag itself, and `:latest` is applied only when the ref is `main`.

**Compose files** - `build:` becomes `image: ${SNOWTRAK_*_IMAGE:?}`. The `:?` is deliberate: an unset variable must abort the deploy rather than quietly resolve to an empty image reference.

**`deploy-backend-vps.yml`** - resolves each service's tag to a digest before touching the box, passes pinned references over SSH, and pulls instead of building. Production accepts `v*` tags only; staging also accepts a 40-char SHA so a `develop` commit can be tested without cutting a release.

## A bug caught in review, not in production

`docker compose down` still parses the Compose file, so with the image variables unset a teardown would have aborted on `:?` instead of stopping the stack. The resolve step now runs for teardowns too and writes placeholder values it never uses. Verified: `docker compose config` succeeds with placeholders.

## Verification done locally

- Compose **refuses** with unset image vars (both files)
- Compose **resolves** to 5 images (production) and 4 (staging) when set
- No `build:` key remains in either file
- Ref-validation logic tested against 8 cases including empty and non-hex input, all pass

## Accepted regression

Staging can no longer deploy an arbitrary feature branch, since images are only published for `main`/`develop`/`restructure`/`v*`. Feature work reaches staging by merging to `develop` first, which is now gated.

## Not yet done

The four GHCR packages must be made **public** before a deploy can pull (Task 8, needs the packages UI). Staging verification with a `v0.0.1-rc1` tag comes after that, before production is ever deployed this way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
