### PR TITLE
Documentation: the workflow is the deploy path

### DIFF
--- a/.github/branch-protection.md
+++ b/.github/branch-protection.md
@@ -1,9 +1,42 @@
-Branch protection rules (recommended):
+# Branch and tag protection
 
-- Protect `main` and `develop` branches.
-- Require pull request reviews before merging (at least one approval).
-- Require passing CI checks and unit tests before merge.
-- Prevent merging PRs that change or add large binary/data files above 5MB.
-- Restrict who can push directly to `main` and `develop` (maintainers only).
+These are applied as GitHub rulesets, not suggestions. The JSON that was
+applied lives in `.github/rulesets/`, and the live state is readable with:
 
-Implement these via GitHub branch protection settings and CODEOWNERS.
+```bash
+gh api repos/Syntraksoftware/Snowtrak/rulesets --jq '.[]|"\(.name) \(.target) \(.enforcement)"'
+```
+
+## `protected-branches` -- `main`, `develop`
+
+- No direct pushes. Changes land through a pull request.
+- No force-pushes, no branch deletion.
+- Zero approvals required, by choice. One person can open and merge their own
+  PR. The brake on *releasing* is at the deploy layer, not here: production and
+  App Store both require an approval from a reviewer.
+- These checks must pass: `Backend Tests`, `Frontend Tests`, `Lint`,
+  `Test (main-backend)`, `Test (community-backend)`, `Test (activity-backend)`,
+  `Test (shared)`, `GitGuardian Security Checks`.
+- `Build, Scan, Push (*)` and `Validate iOS development build` run but do not
+  block. Both have failed on GitHub CDN faults rather than on code -- 429s from
+  `codeload.github.com` and `raw.githubusercontent.com` on 2026-08-17. As
+  required checks, a GitHub incident would block every merge in the repository.
+  Their security value is the scan gate before publish, which is enforced where
+  it matters.
+- No bypass actors. Admins are bound too. An admin editing the ruleset is the
+  break-glass path, and that edit appears in the audit log, which a silent
+  force-push would not.
+
+## `release-tags` -- `v*`
+
+Only repository admins can create, move or delete a `v*` tag.
+
+Branch rules do not cover tags, and a `v` tag is what starts a release: it
+publishes images to GHCR and, for a final version number, opens an App Store
+upload for review. Without this rule, anyone with push access could start
+either.
+
+## What is deliberately not here
+
+There is no CODEOWNERS file. With zero required approvals it would not enforce
+anything, so it would be decoration.

--- a/backend/deploy/README.md
+++ b/backend/deploy/README.md
@@ -87,11 +87,10 @@ git fetch origin && git checkout --detach origin/main
 # 1. The env files are already there from the old layout; confirm, don't rebuild.
 ls -l backend/*-backend/.env
 
-# 2. Build first, while the old stack is still serving. This is the slow part
-#    -- four images on one vCPU -- and doing it before the swap keeps the
-#    outage to the few seconds it takes to stop one stack and start another.
-docker compose -f backend/deploy/docker-compose.production.yml \
-  -p snowtrak-prod build
+# 2. There is nothing to build. Images are built and scanned in CI and pulled
+#    by digest at deploy time, so the slow four-image build on one vCPU is
+#    gone. Run the deploy workflow to bring the new stack up (step 3 shows what
+#    it does on the box).
 
 # 3. Swap. The new stack cannot bind the host ports while the old one holds
 #    them, so the old one goes down first. The old stack has no `name:` in its
@@ -101,8 +100,8 @@ docker compose -f backend/deploy/docker-compose.production.yml \
 #    fails to bind.
 docker compose ls
 docker compose -f backend/docker-compose.yml -p <old-project-name> down
-docker compose -f backend/deploy/docker-compose.production.yml \
-  -p snowtrak-prod up -d
+
+# Then run: Actions -> Deploy Backend to VPS -> production, ref: v1.2.3
 
 # 4. Verify before trusting it. Stop on the first failure -- without the
 #    `|| break` a later passing check masks an earlier one.
@@ -153,6 +152,33 @@ over the other.
 
 `staging-map.syntrak.io` has no DNS record. Add one only if a staging
 map-backend is ever introduced.
+
+## Break glass
+
+**Rolling back.** Re-run the deploy workflow with the previous release tag.
+That is the whole procedure -- images for older tags stay in GHCR, so there is
+nothing to rebuild.
+
+**If Actions is unavailable.** On the box, with digests taken from the last
+good deploy's job summary:
+
+```bash
+cd <VPS_APP_DIR>
+export SNOWTRAK_MAIN_IMAGE=ghcr.io/syntraksoftware/snowtrak-main-backend@sha256:...
+export SNOWTRAK_COMMUNITY_IMAGE=ghcr.io/syntraksoftware/snowtrak-community-backend@sha256:...
+export SNOWTRAK_ACTIVITY_IMAGE=ghcr.io/syntraksoftware/snowtrak-activity-backend@sha256:...
+export SNOWTRAK_MAP_IMAGE=ghcr.io/syntraksoftware/snowtrak-map-backend@sha256:...
+docker compose -f backend/deploy/docker-compose.production.yml -p snowtrak-prod pull
+docker compose -f backend/deploy/docker-compose.production.yml -p snowtrak-prod up -d
+```
+
+This is the only sanctioned manual path, and it exists for the case where the
+normal one is down. It is not a shortcut for a routine deploy.
+
+**The limit of all this.** Anyone with SSH to the droplet can bypass every
+control above. That is a trust boundary, not a technical one. The controls are
+that the bypass is not the documented route, and that SSH access is granted
+narrowly -- not that it is impossible.
 
 ## GitHub environments
 

--- a/docs/developer_handoff.md
+++ b/docs/developer_handoff.md
@@ -68,30 +68,20 @@ The standard path is:
    - triggering the GitHub Actions deploy workflow, or
    - SSHing into the server and pulling the matching branch manually.
 
-Each environment has its own checkout and its own Compose project name. Use
-the right pair -- deploying staging from the production checkout reads the
-wrong revision and the wrong env files, and omitting `-p` lets one stack
-replace the other.
+### Updating the VPS
 
-### Manual VPS update for staging
+Use **Actions -> Deploy Backend to VPS -> Run workflow**. There is no manual
+path for a routine deploy: the workflow pins each service to the image digest
+CI scanned and Trivy passed, which a hand-run `docker compose` does not do.
 
-```bash
-cd /srv/snowtrak-staging      # the staging VPS_APP_DIR, not the production one
-git fetch origin
-git checkout develop
-git reset --hard origin/develop
-docker compose -f backend/deploy/docker-compose.staging.yml -p snowtrak-staging up -d --build
-```
+- staging: `environment: staging`, `ref: v1.2.3` or a 40-character commit SHA
+- production: `environment: production`, `ref: v1.2.3`
 
-### Manual VPS update for production
+Production pauses for a required reviewer before it touches the live stack.
 
-```bash
-cd /srv/syntrak-application   # the production VPS_APP_DIR
-git fetch origin
-git checkout main
-git reset --hard origin/main
-docker compose -f backend/deploy/docker-compose.production.yml -p snowtrak-prod up -d --build
-```
+Feature branches cannot be deployed directly. Images are published only for
+`main`, `develop` and `v*` tags, so feature work reaches staging by merging to
+`develop` first -- which now requires a PR with passing checks.
 
 ## 6. How deployment should work
 

--- a/docs/superpowers/plans/2026-08-20-deploy-authorization.md
+++ b/docs/superpowers/plans/2026-08-20-deploy-authorization.md
@@ -10,6 +10,28 @@
 
 **Spec:** `DEPLOY_AUTHORIZATION_SPEC.md` (repository root)
 
+## Status as of 2026-08-20
+
+| Task | State |
+|---|---|
+| 1. `appstore` environment + reviewer | done — live, verified |
+| 2. iOS reviewer gate, tag pattern narrowed | done — PR #30 |
+| 3. backend-ci always runs | done — PR #30, plus a duplicate-run fix not in this plan |
+| 4. Rulesets installed | done — PR #31, both verified against a live push |
+| 5. Tag trigger for image publish | done — PR #32 |
+| 6. Compose runs published images | done — PR #32 |
+| 7. Deploy by resolved digest | done — PR #32, plus a teardown fix not in this plan |
+| 8. Staging verification | **blocked** — needs the GHCR packages made public, then a UI-run deploy |
+| 9. Documentation | done — PR #33 |
+
+Deviations from this plan, both found while implementing:
+
+- Task 3 gained a scope on the `push:` trigger. Dropping the paths filter left
+  `push` unscoped, so every PR-branch commit ran the five jobs twice.
+- Task 7 gained a teardown branch. `docker compose down` parses the Compose
+  file, so with the image variables unset a `down` would have aborted on `:?`
+  instead of stopping the stack.
+
 ## Global Constraints
 
 - Image names are `ghcr.io/syntraksoftware/snowtrak-<service>` where `<service>` is one of `main-backend`, `community-backend`, `activity-backend`, `map-backend`.

--- a/docs/vps_setup.md
+++ b/docs/vps_setup.md
@@ -157,22 +157,22 @@ Production stack:
 - `activity-backend` on local port `5100`
 - `map-backend` on local port `5200`
 
-## 8. First deploy, manually
+## 8. First deploy
 
-From the repository root on the VPS:
+Deploys run through **Actions -> Deploy Backend to VPS -> Run workflow**. Pick
+the environment and give it a release tag (`v1.2.3`); staging also accepts a
+40-character commit SHA.
 
-Neither Compose file sets a `name:`, so Compose derives the project name from
-the checkout directory. Pass `-p` explicitly -- otherwise two stacks run from
-one checkout share a project name and the second replaces the first. These
-names match `.github/workflows/deploy-backend-vps.yml` and
-`backend/deploy/Caddyfile.example`.
+The workflow resolves each service to a published image digest and the box
+pulls it. **Nothing is built on the VPS.** The image CI scanned with Trivy is
+the image that runs, which is not true of a hand-run `docker compose`.
 
-```bash
-docker compose -f backend/deploy/docker-compose.staging.yml -p snowtrak-staging up -d --build
-docker compose -f backend/deploy/docker-compose.production.yml -p snowtrak-prod up -d --build
-```
+Production pauses for a required reviewer before it touches the live stack.
 
-Check status:
+Check status. `-p` is required: neither Compose file sets a `name:`, so Compose
+would otherwise derive the project from the checkout directory and two stacks
+run from one checkout would collide. These names match
+`.github/workflows/deploy-backend-vps.yml` and `backend/deploy/Caddyfile.example`.
 
 ```bash
 docker compose -f backend/deploy/docker-compose.staging.yml -p snowtrak-staging ps
@@ -182,9 +182,12 @@ docker compose -f backend/deploy/docker-compose.production.yml -p snowtrak-prod 
 Health checks:
 
 ```bash
-curl http://127.0.0.1:18080/health
+# staging
+curl http://127.0.0.1:15080/health
 curl http://127.0.0.1:15001/health
 curl http://127.0.0.1:15100/health
+
+# production
 curl http://127.0.0.1:8080/health
 curl http://127.0.0.1:5001/health
 curl http://127.0.0.1:5100/health


### PR DESCRIPTION
Implements Task 9 of `DEPLOY_AUTHORIZATION_SPEC.md`, the last task that does not require the packages UI or SSH.

## The docs taught the bypass

`vps_setup.md` and `developer_handoff.md` both walked you through SSHing to the box and running `docker compose` by hand. That skips every control added in #30, #31 and #32, and runs an image nothing scanned. Both now point at the workflow as the only routine path.

Two stale details went with them:
- manual commands still said `up -d --build` after the box stopped building
- the staging health check still probed `18080`; staging publishes `15080`

## Break glass, labelled as such

`backend/deploy/README.md` gains a break-glass section: rollback by redeploying the previous tag, plus a hand-run `pull` for when Actions itself is down. It is marked as the exception rather than left looking like an alternative, and it states the limit plainly — anyone with SSH can bypass all of this. That is a trust boundary, not a technical one.

## branch-protection.md now describes reality

It previously listed rules as "recommended" that had never been applied. It now documents what is enforced, including why `Build, Scan, Push (*)` and `Validate iOS development build` are deliberately **not** required checks: both failed on GitHub CDN 429s on 2026-08-17 rather than on code, and as merge gates a GitHub incident would block every merge in the repo.

## Verified

- No bypass instructions remain outside the break-glass section
- No new dead links; the 2 reported are pre-existing and logged as out-of-scope in the spec

## Remaining work

Task 8 (staging verification) is the only thing left, and it needs you: the four GHCR packages must be made public, then a UI-run staging deploy of a `v0.0.1-rc1` tag. Production stays on the old path until that passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
