### PR TITLE
Write down what the first real production deploy cost

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -21,6 +21,25 @@ files are mounted at runtime and are not baked in. Making the packages public
 means the VPS pulls with no credentials, so there is one less secret in the
 deploy path.
 
+Check it without deploying — a token request for a public package needs no
+login, and a 200 means the pull step will work:
+
+```bash
+for s in main community activity map; do
+  img="syntraksoftware/snowtrak-$s-backend"
+  tok=$(curl -sf "https://ghcr.io/token?scope=repository:$img:pull&service=ghcr.io" \
+        | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')
+  printf "%-18s %s\n" "$s" "$(curl -s -o /dev/null -w '%{http_code}' \
+    -H "Authorization: Bearer $tok" "https://ghcr.io/v2/$img/manifests/<tag>")"
+done
+```
+
+**The box itself has preconditions too**, and they are worth checking before a
+release rather than during one: the checkout owned by `VPS_USER`, no local
+modifications in it, an `.env` per service, and credentials in those files that
+are still current. Each is spelled out in
+[backend/deploy/README.md](backend/deploy/README.md#what-the-box-has-to-look-like).
+
 ## The rules, in one place
 
 | Thing | Rule |
@@ -154,8 +173,11 @@ No approval needed. Check `http://127.0.0.1:15080/health` on the box.
 
 Take it down with the same workflow and `action: down`.
 
-Two things to know:
+Three things to know:
 
+- **Staging shares production's Supabase project.** There is only one, so a
+  staging stack reads and writes the live database. It is a code sandbox, not a
+  data one — a like made on staging is a real like.
 - A feature branch cannot be deployed. Images are published only for `main`,
   `develop` and `v*` tags, so merge to `develop` first and deploy its SHA.
 - An `-rc` tag is safe. It deploys to staging but does **not** reach the App
@@ -194,6 +216,10 @@ Takes the same ~3–5 min as a deploy.
 | PR will not merge | One of the 8 required checks has not passed | Check the PR's checks; `Build, Scan, Push` and `Validate iOS` do not block |
 | Health poll times out | One of the four services did not start | The workflow prints the last 30 log lines of each, then rolls back to the previous digests |
 | Deploy fails on `missing env config` | An `.env` on the box has no `SECRET_KEY`/`JWT_SECRET`, `SUPABASE_URL` or `SUPABASE_SERVICE_ROLE_KEY` | Set it — see [backend/deploy/README.md](backend/deploy/README.md#environment-configuration) |
+| `cannot lock ref ... Permission denied` | Something ran `git` as root in the checkout, so the deploy user cannot write `.git` | `chown -R <VPS_USER>:<VPS_USER> <VPS_APP_DIR>` |
+| `Your local changes would be overwritten by checkout` | A tracked file was hand-edited on the box | Back it up outside the repo, then `git checkout -- <file>` |
+| A service starts, then exits on a database error | The `.env` holds a credential that has since been rotated | Update the `.env` in **every** checkout; a running container keeps working on the old one until it restarts, which hides this until a deploy |
+| `(ECIRCUITBREAKER) too many authentication failures` | A container crash-looped against a wrong database password and Supabase blocked new connections | Fix the credential, stop the stack so it stops retrying, wait a few minutes |
 
 ## Break glass
 

--- a/backend/deploy/README.md
+++ b/backend/deploy/README.md
@@ -81,62 +81,76 @@ key before it gets that far.
 Still by hand: `main-backend` reads `ALGORITHM` where the other three read
 `JWT_ALGORITHM`. Both default to HS256, so this only bites if you change one.
 
-## Cutting over from the old layout
+## The cutover, and what it cost
 
-The droplet previously ran `backend/docker-compose.yml` -- the development
-stack. It now binds to `127.0.0.1` as well, so the swap is about the project
-name, Redis persistence, and having a file that is meant for production, not
-about closing an exposure. Built ahead of time, the outage is seconds, not
-minutes.
+Done on 2026-08-25 at `v0.0.2-rc1`. Until then the droplet had run
+`backend/docker-compose.yml` -- the development stack, project name `backend`,
+images built on the box -- continuously for seven weeks. `snowtrak-prod` had
+never started. Every service bound `0.0.0.0` and relied on the cloud firewall;
+they now bind `127.0.0.1`, and Redis publishes no host port at all.
+
+The swap is what it always was: the new stack cannot bind the host ports while
+the old one holds them, so the old one goes down first.
 
 ```bash
 cd <VPS_APP_DIR>
-git fetch origin && git checkout --detach origin/main
+docker compose ls        # confirm the old project name before trusting it
 
-# 1. The env files are already there from the old layout; confirm, don't rebuild.
-ls -l backend/*-backend/.env
+# Pull first. This touches nothing that is running and takes the outage from
+# minutes to seconds.
+for s in main community activity map; do
+  docker pull ghcr.io/syntraksoftware/snowtrak-$s-backend:<tag>
+done
 
-# 2. There is nothing to build. Images are built and scanned in CI and pulled
-#    by digest at deploy time, so the slow four-image build on one vCPU is
-#    gone. Run the deploy workflow to bring the new stack up (step 3 shows what
-#    it does on the box).
+docker compose -f backend/docker-compose.yml -p backend down   # outage starts here
+# then: Actions -> Deploy Backend to VPS -> production, ref: <tag>
+```
 
-# 3. Swap. The new stack cannot bind the host ports while the old one holds
-#    them, so the old one goes down first. The old stack has no `name:` in its
-#    Compose file, so its project name is whatever `docker compose ls` reports
-#    -- Compose derives it from the checkout directory. Confirm, then pass it
-#    explicitly: guessing wrong leaves the old containers up and the new stack
-#    fails to bind.
-docker compose ls
-docker compose -f backend/docker-compose.yml -p <old-project-name> down
+Queue the workflow *before* taking the old stack down: the production
+environment pauses for a reviewer, and the stack stays down for however long
+that approval takes.
 
-# Then run: Actions -> Deploy Backend to VPS -> production, ref: v1.2.3
+Verify, stopping at the first failure so a later pass cannot mask an earlier
+one:
 
-# 4. Verify before trusting it. Stop on the first failure -- without the
-#    `|| break` a later passing check masks an earlier one.
+```bash
 for p in 8080 5001 5100 5200; do
   curl -fsS "http://127.0.0.1:$p/health" && echo " :$p ok" || { echo " :$p FAILED"; break; }
 done
 curl -fsS https://main.syntrak.io/health && echo " public ok"
 ```
 
-Rollback, if the new stack misbehaves:
+Rollback, if the new stack misbehaves. The old images are still on the box as
+`backend-*:latest`, and `backend/docker-compose.yml` is still tracked, so it
+survives the detached checkout the deploy performs:
 
 ```bash
 docker compose -f backend/deploy/docker-compose.production.yml -p snowtrak-prod down
-docker compose -f backend/docker-compose.yml -p <old-project-name> up -d
+docker compose -f backend/docker-compose.yml -p backend up -d
 ```
 
-Nothing carries over from the old stack's Redis, and nothing needs to: it ran
-without a volume, so its data was already lost on every restart. The new
-service has one, plus `appendonly`, so the activity pipeline stream survives a
-restart for the first time. Still worth letting an in-flight upload finish
-before the swap.
+Note that the first production deploy has no automatic rollback. The workflow
+recovers by putting back the digests it replaced, and on a first deploy there
+are no `snowtrak-prod` containers to read them from; it says so and leaves the
+stack for inspection. From the second deploy onwards the net is there.
 
-The env files are untouched by the cutover -- both stacks read the same
-`backend/<service>-backend/.env` files -- so the only differences are the
-project name and Redis gaining persistence. Caddy needs no change: both stacks
-publish the same loopback ports.
+### What the box has to look like
+
+The cutover was planned at under a minute of downtime and took roughly fifteen,
+because three preconditions were only discovered when the deploy hit them. None
+were in the release. All of them are checkable in advance, and a second
+environment will meet them again.
+
+| Requirement | How it failed | Check |
+|---|---|---|
+| The checkout is owned by `VPS_USER` | `git` had been run as root in it, so `git fetch` could not write refs: `cannot lock ref ... Permission denied` | `find <VPS_APP_DIR> -not -user <VPS_USER>` returns nothing |
+| No local modifications in the checkout | `backend/docker-compose.yml` had been hand-edited on the box (a `dns:` override). `git checkout --detach` refuses rather than discard it | `git status --short` shows no ` M` lines |
+| Every service has its `.env`, in **both** checkouts | Staging had none at all, so its first deploy stopped at the env gate | `ls <VPS_APP_DIR>/backend/*-backend/.env` |
+| The env files hold current credentials | They still carried a database password that had since been rotated, so `map-backend` crash-looped until Supabase's auth circuit breaker tripped | Start a throwaway container and connect once, before deploying |
+
+The env gate stops before pulling or starting anything, so a failure there
+changes nothing on the box. The other three do not: they leave you mid-cutover
+with the old stack already down.
 
 ## Staging
 
@@ -163,8 +177,41 @@ environment, so they are separate checkouts and neither can `git reset --hard`
 over the other.
 
 `staging-map.syntrak.io` needs a DNS A record pointing at the droplet, the
-same as the other staging hosts. Until it exists, the staging app's map calls
-fail even though the backend is running.
+same as the other staging hosts. As of 2026-08-25 it still has none, so that
+one hostname does not resolve and Caddy cannot obtain a certificate for it.
+The backend behind it runs regardless -- the deploy health-checks
+`127.0.0.1:15200` on the box, not the public name.
+
+### Caddy is maintained by hand, and was wrong
+
+`Caddyfile.example` is a reference, not something any pipeline applies. Until
+2026-08-25 the live Caddyfile pointed all three staging hostnames at the
+**production** ports:
+
+```
+staging-main.syntrak.io      -> 127.0.0.1:8080    # production main-backend
+staging-community.syntrak.io -> 127.0.0.1:5001    # production community-backend
+staging-activity.syntrak.io  -> 127.0.0.1:5100    # production activity-backend
+```
+
+So "staging" answered every request with production, and had done for as long
+as the hostnames existed. Anything anyone tested on staging was tested against
+the live stack. The correct mapping is the 15xxx range:
+
+| Hostname | Upstream |
+|---|---|
+| `staging-main` | `127.0.0.1:15080` |
+| `staging-community` | `127.0.0.1:15001` |
+| `staging-activity` | `127.0.0.1:15100` |
+| `staging-map` | `127.0.0.1:15200` |
+
+The lesson generalises: a staging hostname that answers is not evidence that
+staging is running. Check what it is proxying to, not whether it returns 200.
+
+Every upstream now imports the `restart_tolerant` snippet, which retries for
+10s so the seconds a container spends restarting during a deploy do not surface
+as 502s. Applied live on 2026-08-25; keep `Caddyfile.example` and the real file
+in step by hand.
 
 ## Break glass
 


### PR DESCRIPTION
The cutover to `snowtrak-prod` happened on 2026-08-25 at `v0.0.2-rc1`. Until then the droplet had run the development Compose stack for seven weeks and the production stack had never started. The runbook described the cutover as something to do; it now records what it changed.

It was planned at under a minute of downtime and took roughly fifteen. None of that was the release — three preconditions failed, each found only when the deploy reached it and the old stack was already down:

- `git` had been run as root in the checkout, so `git fetch` could not write refs
- `backend/docker-compose.yml` had been hand-edited on the box, so the detached checkout refused
- the env files held a database password that had since been rotated, so `map-backend` crash-looped until the Supabase auth circuit breaker tripped

All three are checkable in advance, so they are now a preconditions table with a command each, plus troubleshooting rows carrying the exact error text.

Also recorded: the live Caddyfile pointed all three staging hostnames at **production** ports, so "staging" served production for as long as those names existed. And two things that were assumed rather than known — staging shares the production Supabase project, and the first production deploy has no automatic rollback.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded deployment checklists for package access, server readiness, environment configuration, and credentials.
  * Added staging safety guidance, including its connection to live data.
  * Documented production migration results, rollback procedures, health checks, and service prerequisites.
  * Added troubleshooting guidance for checkout permissions, local changes, credentials, and authentication failures.
  * Recorded staging DNS, routing corrections, and current proxy configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->