### PR TITLE
docs(follows): point the push-notification gap at its issue

### DIFF
--- a/docs/superpowers/specs/2026-08-26-follower-mechanism-design.md
+++ b/docs/superpowers/specs/2026-08-26-follower-mechanism-design.md
@@ -300,9 +300,14 @@ Named so they are decisions rather than oversights:
 - **Blocking** — moderation, not social graph.
 - **A mutual-only "friends" tier** — a third check on every read and a
   three-way picker, for a tier nobody has asked for yet.
-- **New-follower push notifications** — `notifications.py` has a `follow` type,
-  but only behind `/test/follow`. There is no real send path from a backend
-  event; building one is its own change.
+- **Push notifications** — tracked in
+  [#41](https://github.com/Syntraksoftware/Snowtrak/issues/41), which carries
+  the investigation: FCM is the chosen provider, ~610 lines of sender already
+  sit unmerged on `feat/build-notification-service`, and the real obstacle is
+  that `frontend/android/` holds two files and does not build. `notifications.py`
+  and its `/test/follow` endpoint are gone as of #40; the in-app list is derived
+  from pending follow requests instead, which is why `markAsRead` does not
+  persist.
 - **Follow suggestions / "people you may know"** — needs a graph before it can
   recommend anything.
 - **Feed ranking** — this change makes relevance *possible* by capturing the


### PR DESCRIPTION
Records the deferral of push notifications, decided 2026-09-01.

The follower spec's out-of-scope bullet described a send path through `notifications.py`, which #40 deleted. Updated to point at #41, which holds the investigation — including the part that is not visible from the tree: `frontend/android/` holds two files and does not build, so FCM's one-SDK-for-both-platforms argument buys nothing yet.

Docs only. Nothing in `CHANGELOG.md`: per `docs/changelog_style.md` it carries released changes with a commit link each and has no Unreleased section, so planned work has nowhere to sit in it.

Closes nothing. Tracked in #41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015npbKaSNS6MbCJi4Khs54M