### PR TITLE
feat(competition): duel mode and the global leaderboard

### DIFF
--- a/backend/activity-backend/domain/__init__.py
+++ b/backend/activity-backend/domain/__init__.py
@@ -1,0 +1,6 @@
+"""Pure domain rules for activity-backend.
+
+Nothing under `domain/` imports a client, a config or a route. It is a
+function of values that have already been read, which is what lets the rules
+be tested without a network and changed without touching persistence.
+"""

--- a/backend/activity-backend/domain/competition/__init__.py
+++ b/backend/activity-backend/domain/competition/__init__.py
@@ -1,0 +1,1 @@
+"""Competition rules: scoring, windows and duel state."""

--- a/backend/activity-backend/domain/competition/duel.py
+++ b/backend/activity-backend/domain/competition/duel.py
@@ -1,0 +1,174 @@
+"""Duel state: what a duel is, and which transitions are legal.
+
+The rules live here so that "can this person accept this challenge" is a
+question about values rather than a question about the database. Persistence
+enforces the same rules a second time with a conditional update; this module
+is what makes them readable.
+
+Design: docs/superpowers/specs/2026-09-02-duel-and-leaderboard-design.md
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from enum import StrEnum
+from typing import Any
+
+from domain.competition.metrics import Duration, Metric
+
+#: How long an unanswered challenge stands before the settlement sweep
+#: expires it. Long enough to survive a day off the app, short enough that a
+#: forgotten invitation does not block the pair's next duel indefinitely.
+INVITE_TTL = timedelta(hours=48)
+
+
+class DuelStatus(StrEnum):
+    """Where a duel is in its life."""
+
+    PENDING = "pending"
+    ACTIVE = "active"
+    FINISHED = "finished"
+    DECLINED = "declined"
+    CANCELLED = "cancelled"
+    EXPIRED = "expired"
+
+
+#: Every legal move. Anything absent is terminal, which is most of them: a
+#: declined duel is not re-opened, it is superseded by a new challenge.
+_TRANSITIONS: dict[DuelStatus, frozenset[DuelStatus]] = {
+    DuelStatus.PENDING: frozenset(
+        {
+            DuelStatus.ACTIVE,
+            DuelStatus.DECLINED,
+            DuelStatus.CANCELLED,
+            DuelStatus.EXPIRED,
+        }
+    ),
+    DuelStatus.ACTIVE: frozenset({DuelStatus.FINISHED}),
+}
+
+LIVE_STATUSES = frozenset({DuelStatus.PENDING, DuelStatus.ACTIVE})
+
+
+def can_transition(current: DuelStatus, target: DuelStatus) -> bool:
+    """Whether `current` is allowed to become `target`."""
+    return target in _TRANSITIONS.get(current, frozenset())
+
+
+@dataclass(frozen=True)
+class Duel:
+    """One head-to-head, as read from the `duels` table."""
+
+    id: str
+    challenger_id: str
+    opponent_id: str
+    metric: Metric
+    duration: Duration
+    status: DuelStatus
+    created_at: datetime
+    starts_at: datetime | None = None
+    ends_at: datetime | None = None
+    challenger_value: float | None = None
+    opponent_value: float | None = None
+    winner_id: str | None = None
+    settled_at: datetime | None = None
+
+    @classmethod
+    def from_row(cls, row: dict[str, Any]) -> Duel:
+        """Builds a duel from a `duels` row.
+
+        Raises:
+            ValueError: If the row carries a metric, duration or status this
+                version does not know. Failing here beats scoring a duel by
+                a rule we cannot name.
+        """
+        return cls(
+            id=str(row["id"]),
+            challenger_id=str(row["challenger_id"]),
+            opponent_id=str(row["opponent_id"]),
+            metric=Metric(row["metric"]),
+            duration=Duration(row["duration"]),
+            status=DuelStatus(row["status"]),
+            created_at=_moment(row["created_at"]),
+            starts_at=_optional_moment(row.get("starts_at")),
+            ends_at=_optional_moment(row.get("ends_at")),
+            challenger_value=row.get("challenger_value"),
+            opponent_value=row.get("opponent_value"),
+            winner_id=_optional_str(row.get("winner_id")),
+            settled_at=_optional_moment(row.get("settled_at")),
+        )
+
+    def involves(self, user_id: str) -> bool:
+        """Whether `user_id` is one of the two players."""
+        return user_id in (self.challenger_id, self.opponent_id)
+
+    def opponent_of(self, user_id: str) -> str:
+        """The other player.
+
+        Raises:
+            ValueError: If `user_id` is not in this duel.
+        """
+        if user_id == self.challenger_id:
+            return self.opponent_id
+        if user_id == self.opponent_id:
+            return self.challenger_id
+        raise ValueError("user is not a player in this duel")
+
+    def is_expired_at(self, now: datetime) -> bool:
+        """Whether an unanswered challenge has outlived `INVITE_TTL`."""
+        return self.status is DuelStatus.PENDING and self.created_at + INVITE_TTL <= now
+
+    def is_decidable_at(self, now: datetime) -> bool:
+        """Whether the window has closed and a winner can be written."""
+        return self.status is DuelStatus.ACTIVE and self.ends_at is not None and self.ends_at <= now
+
+    def may_accept(self, viewer_id: str, now: datetime) -> bool:
+        """Only the challenged player, only while the invitation stands."""
+        return (
+            viewer_id == self.opponent_id
+            and self.status is DuelStatus.PENDING
+            and not self.is_expired_at(now)
+        )
+
+    def may_decline(self, viewer_id: str, now: datetime) -> bool:
+        """Declining and accepting are open to the same person at the same
+        times."""
+        return self.may_accept(viewer_id, now)
+
+    def may_cancel(self, viewer_id: str) -> bool:
+        """Withdrawing is the challenger's, and only before it is accepted."""
+        return viewer_id == self.challenger_id and self.status is DuelStatus.PENDING
+
+
+def resolve_winner(duel: Duel, challenger_value: float, opponent_value: float) -> str | None:
+    """Decides a finished duel.
+
+    Args:
+        duel: The duel being settled.
+        challenger_value: The challenger's score, already comparable -- see
+            `metrics.score`, where every metric is normalised so that higher
+            wins.
+        opponent_value: The opponent's score.
+
+    Returns:
+        The winner's user id, or `None` for a draw. Two players who both
+        recorded nothing draw at zero; that is a draw, not a loss for both.
+    """
+    if challenger_value > opponent_value:
+        return duel.challenger_id
+    if opponent_value > challenger_value:
+        return duel.opponent_id
+    return None
+
+
+def _moment(value: Any) -> datetime:
+    return value if isinstance(value, datetime) else datetime.fromisoformat(value)
+
+
+def _optional_moment(value: Any) -> datetime | None:
+    return None if value is None else _moment(value)
+
+
+def _optional_str(value: Any) -> str | None:
+    return None if value is None else str(value)

--- a/backend/activity-backend/domain/competition/metrics.py
+++ b/backend/activity-backend/domain/competition/metrics.py
@@ -1,0 +1,120 @@
+"""Scoring rules shared by duels and the leaderboard.
+
+Both features reduce to the same question: given one column of `activities`
+over one window, what is the single number that ranks a user? This module is
+that question and nothing else -- no client, no query, no I/O.
+
+Design: docs/superpowers/specs/2026-09-02-duel-and-leaderboard-design.md
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import UTC, date, datetime, time, timedelta
+from enum import StrEnum
+
+SECONDS_PER_HOUR = 3600
+
+
+class Metric(StrEnum):
+    """What a board or a duel is measured on."""
+
+    VERTICAL = "vertical"
+    SPEED = "speed"
+    DISTANCE = "distance"
+
+
+class Duration(StrEnum):
+    """How long a duel window runs."""
+
+    TODAY = "today"
+    WEEKEND = "weekend"
+    WEEK = "week"
+
+
+#: The `activities` column each metric reads. Speed reads `max_pace`, which
+#: `score` then has to invert -- see there for why it is not a plain sum.
+METRIC_COLUMNS: dict[Metric, str] = {
+    Metric.VERTICAL: "elevation_gain_meters",
+    Metric.DISTANCE: "distance_meters",
+    Metric.SPEED: "max_pace",
+}
+
+
+def score(metric: Metric, values: Iterable[float | None]) -> float:
+    """Reduces one activity column to a single comparable number.
+
+    Higher always wins, for every metric. Speed is the reason that needs
+    saying: `activities.max_pace` is seconds per kilometre, so the fastest
+    run is the *smallest* positive value, and the column defaults to 0 when
+    there is no reading rather than meaning infinitely fast. Converting to
+    km/h here means every caller can order descending and every value on a
+    board reads the same direction.
+
+    Args:
+        metric: Which rule to apply.
+        values: The metric's column, one entry per activity in the window.
+
+    Returns:
+        Kilometres per hour for `SPEED`; the column's own unit, summed, for
+        the others. Zero when nothing in `values` counts.
+    """
+    if metric is Metric.SPEED:
+        paces = [v for v in values if v is not None and v > 0]
+        return SECONDS_PER_HOUR / min(paces) if paces else 0.0
+    return float(sum(v for v in values if v is not None))
+
+
+def week_start(moment: datetime) -> date:
+    """Monday of the UTC week containing `moment`.
+
+    Matches the `week_start` convention `user_stats` already uses, so the two
+    do not disagree about which week an activity belongs to.
+    """
+    day = moment.astimezone(UTC).date()
+    return day - timedelta(days=day.weekday())
+
+
+def week_bounds(moment: datetime) -> tuple[datetime, datetime]:
+    """Half-open UTC bounds of the week containing `moment`.
+
+    Returns:
+        `(start, end)` where an activity counts if `start <= start_time <
+        end`. Half-open so no activity lands in two consecutive weeks.
+    """
+    start = datetime.combine(week_start(moment), time.min, tzinfo=UTC)
+    return start, start + timedelta(days=7)
+
+
+def duel_window(duration: Duration, accepted_at: datetime) -> tuple[datetime, datetime]:
+    """Bounds of a duel window, given when the challenge was accepted.
+
+    The window opens at acceptance, never before, so neither player can bank
+    a head start by choosing when to send the challenge. Both players get
+    the same bounds, so a late acceptance shortens the duel for both rather
+    than handicapping one.
+
+    `WEEKEND` is the exception to "opens at acceptance": it opens on Friday
+    when accepted earlier in the week, because a Friday-to-Sunday duel that
+    silently counted Tuesday would not be the duel the label promised. It
+    still never opens in the past.
+
+    Args:
+        duration: The chosen window length.
+        accepted_at: When the opponent accepted.
+
+    Returns:
+        `(starts_at, ends_at)`, half-open, both UTC.
+    """
+    now = accepted_at.astimezone(UTC)
+    midnight = datetime.combine(now.date(), time.min, tzinfo=UTC)
+
+    if duration is Duration.TODAY:
+        return now, midnight + timedelta(days=1)
+
+    if duration is Duration.WEEK:
+        return now, now + timedelta(days=7)
+
+    monday = datetime.combine(week_start(now), time.min, tzinfo=UTC)
+    friday = monday + timedelta(days=4)
+    return max(now, friday), monday + timedelta(days=7)

--- a/backend/activity-backend/main.py
+++ b/backend/activity-backend/main.py
@@ -18,6 +18,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from supabase import create_client
 
 # Add backend directory to path for shared imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -28,7 +29,13 @@ from shared.rate_limiter import add_redis_rate_limiter
 
 from config import get_config
 from routes.activities import router as activities_router
+from routes.duel_record_routes import router as duel_record_router
+from routes.duel_routes import router as duel_router
+from routes.leaderboard_routes import router as leaderboard_router
+from services.duel_operations import initialize_duel_operations
+from services.leaderboard_operations import initialize_leaderboard_operations
 from services.pipeline_worker import PipelineWorker
+from services.settlement_worker import SettlementWorker
 from services.supabase_client import initialize_activity_client
 from services.user_stats_service import initialize_stats_service
 
@@ -66,8 +73,8 @@ def _get_rate_limit_policies() -> list[dict]:
 def _log_owned_domains_banner() -> None:
     """Log owned domains and canonical routes at startup."""
     logger.info("SERVICE OWNERSHIP: activity-backend")
-    logger.info("domains: activities")
-    logger.info("routes: /api/v1/activities")
+    logger.info("domains: activities, competition")
+    logger.info("routes: /api/v1/activities, /api/v1/leaderboard, /api/v1/duels")
 
 
 @asynccontextmanager
@@ -78,19 +85,28 @@ async def lifespan(app: FastAPI):
 
     initialize_activity_client()
     initialize_stats_service()
+    # Duels and the board aggregate `activities` and read `profiles`, so they
+    # take the raw client rather than ActivitySupabaseClient's activity-shaped
+    # surface. One client, two singletons.
+    competition_client = create_client(config.SUPABASE_URL, config.SUPABASE_SERVICE_ROLE_KEY)
+    initialize_duel_operations(competition_client)
+    initialize_leaderboard_operations(competition_client)
     _log_owned_domains_banner()
 
-    worker = PipelineWorker()
-    worker_task = asyncio.create_task(worker.run_forever())
+    workers = [PipelineWorker(), SettlementWorker()]
+    tasks = [asyncio.create_task(worker.run_forever()) for worker in workers]
 
     yield
 
-    worker.stop()
-    worker_task.cancel()
+    for worker in workers:
+        worker.stop()
+    for task in tasks:
+        task.cancel()
     # cancel() always surfaces as CancelledError here; awaiting is only to let
-    # the task finish unwinding before the process exits.
-    with contextlib.suppress(asyncio.CancelledError):
-        await worker_task
+    # the tasks finish unwinding before the process exits.
+    for task in tasks:
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
     logger.info("Shutting down Activity Backend")
 
 
@@ -146,6 +162,9 @@ app.add_middleware(
 
 # Routers
 app.include_router(activities_router)
+app.include_router(leaderboard_router)
+app.include_router(duel_router)
+app.include_router(duel_record_router)
 
 
 @app.get("/")

--- a/backend/activity-backend/models.py
+++ b/backend/activity-backend/models.py
@@ -64,6 +64,7 @@ class ActivityUpdate(BaseModel):
     name: str | None = None
     description: str | None = None
     visibility: str | None = None
+    on_leaderboard: bool | None = None
 
 
 class FrontendActivityUpdate(BaseModel):
@@ -72,6 +73,9 @@ class FrontendActivityUpdate(BaseModel):
     name: str | None = None
     description: str | None = None
     is_public: bool | None = None
+    # Whether this activity counts towards the global leaderboard. Opt-in is
+    # per activity, so this is the only place it is ever set.
+    on_leaderboard: bool | None = None
 
 
 class ActivityResponse(BaseModel):
@@ -107,6 +111,7 @@ class FrontendActivityResponse(BaseModel):
     max_pace: float | None = None
     calories: int | None = None
     is_public: bool
+    on_leaderboard: bool = False
     created_at: str | None = None
     locations: list[FrontendLocation] = Field(default_factory=list)
     map_activity_id: str | None = None
@@ -204,7 +209,7 @@ class UserStatsResponse(BaseModel):
     """Cached user stats returned by GET /me/stats."""
 
     user_id: str
-    week_start: str                     # ISO date string (Monday)
+    week_start: str  # ISO date string (Monday)
 
     weekly_distance_km: float
     weekly_time_min: int
@@ -225,5 +230,5 @@ class UserStatsResponse(BaseModel):
     current_streak_weeks: int
     longest_streak_weeks: int
 
-    activity_days: list[str]            # Sorted ISO date strings
+    activity_days: list[str]  # Sorted ISO date strings
     best_efforts: list[BestEffort]

--- a/backend/activity-backend/routes/activities_management_routes.py
+++ b/backend/activity-backend/routes/activities_management_routes.py
@@ -175,6 +175,7 @@ async def update_activity(
             name=data.name,
             description=data.description,
             visibility=visibility_value,
+            on_leaderboard=data.on_leaderboard,
         )
 
         if not updated_activity:

--- a/backend/activity-backend/routes/activity_transformers.py
+++ b/backend/activity-backend/routes/activity_transformers.py
@@ -173,6 +173,7 @@ def map_activity_to_frontend_payload(
         "max_pace": activity_record.get("max_pace"),
         "calories": activity_record.get("calories"),
         "is_public": activity_record.get("visibility") == "public",
+        "on_leaderboard": bool(activity_record.get("on_leaderboard")),
         "created_at": created_at_value,
         "locations": convert_to_frontend_locations(activity_record.get("id"), gps_path_records),
         "map_activity_id": activity_record.get("map_activity_id"),

--- a/backend/activity-backend/routes/competition_models.py
+++ b/backend/activity-backend/routes/competition_models.py
@@ -1,0 +1,93 @@
+"""Request and response schemas for duels and the leaderboard.
+
+These are the API contract: snake_case keys, ISO 8601 UTC timestamps, and a
+Dart model mirroring each one. A shape change here is a two-sided break --
+see docs/api_standardization.md.
+"""
+
+from pydantic import BaseModel, Field
+
+from domain.competition.duel import DuelStatus
+from domain.competition.metrics import Duration, Metric
+
+
+class LeaderboardEntry(BaseModel):
+    """One row of a board."""
+
+    rank: int
+    user_id: str
+    value: float
+    display_name: str
+    username: str | None = None
+    avatar_url: str | None = None
+    country_code: str | None = None
+
+
+class LeaderboardResponse(BaseModel):
+    """A board page, plus the terms it was read under."""
+
+    metric: Metric
+    scope: str
+    week_start: str = Field(..., description="ISO date of the Monday, UTC")
+    settled: bool = Field(
+        ...,
+        description="True for a snapshot of a finished week, false for the live board",
+    )
+    entries: list[LeaderboardEntry]
+
+
+class LeaderboardPlacing(BaseModel):
+    """Where the caller stands, however deep in the board."""
+
+    metric: Metric
+    scope: str
+    week_start: str
+    rank: int | None = None
+    value: float = 0.0
+
+
+class DuelCreate(BaseModel):
+    """Terms of a challenge. The window is not chosen here -- it opens when
+    the opponent accepts."""
+
+    opponent_id: str
+    metric: Metric
+    duration: Duration
+
+
+class DuelResponse(BaseModel):
+    """One duel, as both players see it."""
+
+    id: str
+    challenger_id: str
+    opponent_id: str
+    metric: Metric
+    duration: Duration
+    status: DuelStatus
+    created_at: str
+    starts_at: str | None = None
+    ends_at: str | None = None
+    challenger_value: float | None = None
+    opponent_value: float | None = None
+    winner_id: str | None = None
+    settled_at: str | None = None
+
+
+class DuelsListResponse(BaseModel):
+    """A page of duels."""
+
+    items: list[DuelResponse]
+    total: int
+
+
+class DuelRecord(BaseModel):
+    """A player's head-to-head history."""
+
+    user_id: str
+    wins: int
+    losses: int
+    draws: int
+    recent: list[str] = Field(
+        default_factory=list,
+        description="Most recent results first, each 'W', 'L' or 'D'",
+    )

--- a/backend/activity-backend/routes/competition_models.py
+++ b/backend/activity-backend/routes/competition_models.py
@@ -71,6 +71,13 @@ class DuelResponse(BaseModel):
     opponent_value: float | None = None
     winner_id: str | None = None
     settled_at: str | None = None
+    # Filled from one profiles read per page, so a list of duels never
+    # becomes a profile fetch per card. Never null: a player with no
+    # profiles row gets the placeholder in duel_routes.
+    challenger_name: str | None = None
+    challenger_avatar_url: str | None = None
+    opponent_name: str | None = None
+    opponent_avatar_url: str | None = None
 
 
 class DuelsListResponse(BaseModel):

--- a/backend/activity-backend/routes/duel_record_routes.py
+++ b/backend/activity-backend/routes/duel_record_routes.py
@@ -1,0 +1,29 @@
+"""A player's win/loss record.
+
+Its own router because it hangs off /users, not /duels: the profile header
+asks for it by user id, and nesting it under a duel id would be a lie about
+what it belongs to.
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends
+
+from middleware.auth import get_current_user
+from routes.competition_models import DuelRecord
+from services.duel_operations import get_duel_operations
+from services.offload import offload
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/v1/users", tags=["duels"])
+
+
+@router.get("/{user_id}/duel_record", response_model=DuelRecord)
+async def duel_record(user_id: str, _: str = Depends(get_current_user)):
+    """Wins, losses, draws and recent form.
+
+    Public to any signed-in caller: a record is a scoreboard, and it names
+    no activity and no opponent.
+    """
+    record = await offload(get_duel_operations().record, user_id)
+    return DuelRecord(user_id=user_id, **record)

--- a/backend/activity-backend/routes/duel_routes.py
+++ b/backend/activity-backend/routes/duel_routes.py
@@ -30,7 +30,16 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v1/duels", tags=["duels"])
 
 
-def _response(duel: Duel) -> DuelResponse:
+def _response(duel: Duel, players: dict[str, dict] | None = None) -> DuelResponse:
+    """One duel, with display fields when the caller has already read them.
+
+    `players` is optional so a single-duel handler does not pay for a
+    profiles round trip it has no use for; the list handler passes one map
+    for the whole page.
+    """
+    people = players or {}
+    challenger = people.get(duel.challenger_id, {})
+    opponent = people.get(duel.opponent_id, {})
     return DuelResponse(
         id=duel.id,
         challenger_id=duel.challenger_id,
@@ -45,6 +54,10 @@ def _response(duel: Duel) -> DuelResponse:
         opponent_value=duel.opponent_value,
         winner_id=duel.winner_id,
         settled_at=duel.settled_at.isoformat() if duel.settled_at else None,
+        challenger_name=challenger.get("display_name"),
+        challenger_avatar_url=challenger.get("avatar_url"),
+        opponent_name=opponent.get("display_name"),
+        opponent_avatar_url=opponent.get("avatar_url"),
     )
 
 
@@ -124,7 +137,8 @@ async def get_duel(duel_id: str, user_id: str = Depends(get_current_user)):
         settled = await offload(get_duel_operations().settle, duel)
         if settled is not None:
             duel = settled
-    return _response(duel)
+    players = await offload(get_duel_operations().players, [duel])
+    return _response(duel, players)
 
 
 @router.post("/{duel_id}/accept", response_model=DuelResponse)

--- a/backend/activity-backend/routes/duel_routes.py
+++ b/backend/activity-backend/routes/duel_routes.py
@@ -24,22 +24,22 @@ from services.duel_operations import (
     NotEligible,
     get_duel_operations,
 )
+from services.leaderboard_operations import UNKNOWN_PLAYER
 from services.offload import offload
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v1/duels", tags=["duels"])
 
 
-def _response(duel: Duel, players: dict[str, dict] | None = None) -> DuelResponse:
-    """One duel, with display fields when the caller has already read them.
+def _response(duel: Duel, players: dict[str, dict]) -> DuelResponse:
+    """One duel, with the display fields its caller already read.
 
-    `players` is optional so a single-duel handler does not pay for a
-    profiles round trip it has no use for; the list handler passes one map
-    for the whole page.
+    `players` is required, not optional. It was optional, and every handler
+    that forgot it returned a duel with null names -- silently, because a
+    null name renders as a blank rather than as an error.
     """
-    people = players or {}
-    challenger = people.get(duel.challenger_id, {})
-    opponent = people.get(duel.opponent_id, {})
+    challenger = players.get(duel.challenger_id) or {}
+    opponent = players.get(duel.opponent_id) or {}
     return DuelResponse(
         id=duel.id,
         challenger_id=duel.challenger_id,
@@ -54,27 +54,34 @@ def _response(duel: Duel, players: dict[str, dict] | None = None) -> DuelRespons
         opponent_value=duel.opponent_value,
         winner_id=duel.winner_id,
         settled_at=duel.settled_at.isoformat() if duel.settled_at else None,
-        challenger_name=challenger.get("display_name"),
+        challenger_name=challenger.get("display_name") or UNKNOWN_PLAYER,
         challenger_avatar_url=challenger.get("avatar_url"),
-        opponent_name=opponent.get("display_name"),
+        opponent_name=opponent.get("display_name") or UNKNOWN_PLAYER,
         opponent_avatar_url=opponent.get("avatar_url"),
     )
 
 
-async def _visible_duel(duel_id: str, viewer_id: str) -> Duel:
-    """Loads a duel the caller is a player in.
+async def _visible_duel(duel_id: str, viewer_id: str) -> tuple[Duel, dict[str, dict]]:
+    """Loads a duel the caller is a player in, with both players' names.
 
     404 rather than 403 for someone else's duel: who is challenging whom is
     not a stranger's business, so "not yours" and "does not exist" look the
     same from outside.
 
+    Returns:
+        The duel and its player lookup. Answering a duel does not change who
+        is in it, so the handlers reuse this map rather than reading profiles
+        again after the write.
+
     Raises:
         HTTPException: 404 if it is missing or not the caller's.
     """
-    duel = await offload(get_duel_operations().get, duel_id)
+    operations = get_duel_operations()
+    duel = await offload(operations.get, duel_id)
     if duel is None or not duel.involves(viewer_id):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Duel not found")
-    return duel
+    players = await offload(operations.players, [duel])
+    return duel, players
 
 
 @router.post("", response_model=DuelResponse, status_code=status.HTTP_201_CREATED)
@@ -90,9 +97,10 @@ async def create_duel(payload: DuelCreate, user_id: str = Depends(get_current_us
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="You cannot duel yourself",
         )
+    operations = get_duel_operations()
     try:
         duel = await offload(
-            get_duel_operations().create,
+            operations.create,
             user_id,
             payload.opponent_id,
             payload.metric,
@@ -108,7 +116,8 @@ async def create_duel(payload: DuelCreate, user_id: str = Depends(get_current_us
             status_code=status.HTTP_409_CONFLICT,
             detail="A duel between you two is already under way",
         ) from None
-    return _response(duel)
+    players = await offload(operations.players, [duel])
+    return _response(duel, players)
 
 
 @router.get("", response_model=DuelsListResponse)
@@ -119,8 +128,11 @@ async def list_duels(
     user_id: str = Depends(get_current_user),
 ):
     """The caller's duels, newest first."""
-    duels = await offload(get_duel_operations().list_for, user_id, duel_status, limit, offset)
-    items = [_response(duel) for duel in duels]
+    operations = get_duel_operations()
+    duels = await offload(operations.list_for, user_id, duel_status, limit, offset)
+    # One profiles read for the whole page, never one per card.
+    players = await offload(operations.players, duels)
+    items = [_response(duel, players) for duel in duels]
     return DuelsListResponse(items=items, total=len(items))
 
 
@@ -132,12 +144,11 @@ async def get_duel(duel_id: str, user_id: str = Depends(get_current_user)):
     opening a finished duel should see the result rather than a countdown
     that has already run out.
     """
-    duel = await _visible_duel(duel_id, user_id)
+    duel, players = await _visible_duel(duel_id, user_id)
     if duel.is_decidable_at(datetime.now(UTC)):
         settled = await offload(get_duel_operations().settle, duel)
         if settled is not None:
             duel = settled
-    players = await offload(get_duel_operations().players, [duel])
     return _response(duel, players)
 
 
@@ -149,7 +160,7 @@ async def accept_duel(duel_id: str, user_id: str = Depends(get_current_user)):
         HTTPException: 409 if the caller may not accept -- not theirs to
             answer, already answered, or lapsed.
     """
-    duel = await _visible_duel(duel_id, user_id)
+    duel, players = await _visible_duel(duel_id, user_id)
     if not duel.may_accept(user_id, datetime.now(UTC)):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -161,7 +172,7 @@ async def accept_duel(duel_id: str, user_id: str = Depends(get_current_user)):
             status_code=status.HTTP_409_CONFLICT,
             detail="This challenge can no longer be accepted",
         )
-    return _response(accepted)
+    return _response(accepted, players)
 
 
 @router.post("/{duel_id}/decline", response_model=DuelResponse)
@@ -172,7 +183,7 @@ async def decline_duel(duel_id: str, user_id: str = Depends(get_current_user)):
         HTTPException: 409 if it is not the caller's to refuse, or no longer
             pending.
     """
-    duel = await _visible_duel(duel_id, user_id)
+    duel, players = await _visible_duel(duel_id, user_id)
     if not duel.may_decline(user_id, datetime.now(UTC)):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -184,7 +195,7 @@ async def decline_duel(duel_id: str, user_id: str = Depends(get_current_user)):
             status_code=status.HTTP_409_CONFLICT,
             detail="This challenge can no longer be declined",
         )
-    return _response(declined)
+    return _response(declined, players)
 
 
 @router.delete("/{duel_id}", response_model=DuelResponse)
@@ -195,7 +206,7 @@ async def cancel_duel(duel_id: str, user_id: str = Depends(get_current_user)):
         HTTPException: 409 once it has been accepted -- an active duel is
             played out, not taken back.
     """
-    duel = await _visible_duel(duel_id, user_id)
+    duel, players = await _visible_duel(duel_id, user_id)
     if not duel.may_cancel(user_id):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -207,4 +218,4 @@ async def cancel_duel(duel_id: str, user_id: str = Depends(get_current_user)):
             status_code=status.HTTP_409_CONFLICT,
             detail="Only a pending challenge can be withdrawn",
         )
-    return _response(cancelled)
+    return _response(cancelled, players)

--- a/backend/activity-backend/routes/duel_routes.py
+++ b/backend/activity-backend/routes/duel_routes.py
@@ -1,0 +1,196 @@
+"""Duel routes.
+
+Eligibility, legality and settlement are decided in the domain and enforced
+again as conditions on each update. These handlers translate between HTTP
+and that, and do nothing else.
+"""
+
+import logging
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from domain.competition.duel import Duel, DuelStatus
+from middleware.auth import get_current_user
+from routes.competition_models import (
+    DuelCreate,
+    DuelResponse,
+    DuelsListResponse,
+)
+from services.duel_operations import (
+    DEFAULT_LIMIT,
+    MAX_LIMIT,
+    DuelInProgress,
+    NotEligible,
+    get_duel_operations,
+)
+from services.offload import offload
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/v1/duels", tags=["duels"])
+
+
+def _response(duel: Duel) -> DuelResponse:
+    return DuelResponse(
+        id=duel.id,
+        challenger_id=duel.challenger_id,
+        opponent_id=duel.opponent_id,
+        metric=duel.metric,
+        duration=duel.duration,
+        status=duel.status,
+        created_at=duel.created_at.isoformat(),
+        starts_at=duel.starts_at.isoformat() if duel.starts_at else None,
+        ends_at=duel.ends_at.isoformat() if duel.ends_at else None,
+        challenger_value=duel.challenger_value,
+        opponent_value=duel.opponent_value,
+        winner_id=duel.winner_id,
+        settled_at=duel.settled_at.isoformat() if duel.settled_at else None,
+    )
+
+
+async def _visible_duel(duel_id: str, viewer_id: str) -> Duel:
+    """Loads a duel the caller is a player in.
+
+    404 rather than 403 for someone else's duel: who is challenging whom is
+    not a stranger's business, so "not yours" and "does not exist" look the
+    same from outside.
+
+    Raises:
+        HTTPException: 404 if it is missing or not the caller's.
+    """
+    duel = await offload(get_duel_operations().get, duel_id)
+    if duel is None or not duel.involves(viewer_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Duel not found")
+    return duel
+
+
+@router.post("", response_model=DuelResponse, status_code=status.HTTP_201_CREATED)
+async def create_duel(payload: DuelCreate, user_id: str = Depends(get_current_user)):
+    """Challenges someone who follows you back.
+
+    Raises:
+        HTTPException: 403 when the two do not follow each other, 409 when a
+            duel between them already stands, 422 for a self-challenge.
+    """
+    if payload.opponent_id == user_id:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="You cannot duel yourself",
+        )
+    try:
+        duel = await offload(
+            get_duel_operations().create,
+            user_id,
+            payload.opponent_id,
+            payload.metric,
+            payload.duration,
+        )
+    except NotEligible:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You can only duel someone who follows you back",
+        ) from None
+    except DuelInProgress:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="A duel between you two is already under way",
+        ) from None
+    return _response(duel)
+
+
+@router.get("", response_model=DuelsListResponse)
+async def list_duels(
+    duel_status: DuelStatus | None = Query(None, alias="status"),
+    limit: int = Query(DEFAULT_LIMIT, ge=1, le=MAX_LIMIT),
+    offset: int = Query(0, ge=0),
+    user_id: str = Depends(get_current_user),
+):
+    """The caller's duels, newest first."""
+    duels = await offload(get_duel_operations().list_for, user_id, duel_status, limit, offset)
+    items = [_response(duel) for duel in duels]
+    return DuelsListResponse(items=items, total=len(items))
+
+
+@router.get("/{duel_id}", response_model=DuelResponse)
+async def get_duel(duel_id: str, user_id: str = Depends(get_current_user)):
+    """One duel, settled on the spot if its window has closed.
+
+    The background sweep would get to it within five minutes, but a player
+    opening a finished duel should see the result rather than a countdown
+    that has already run out.
+    """
+    duel = await _visible_duel(duel_id, user_id)
+    if duel.is_decidable_at(datetime.now(UTC)):
+        settled = await offload(get_duel_operations().settle, duel)
+        if settled is not None:
+            duel = settled
+    return _response(duel)
+
+
+@router.post("/{duel_id}/accept", response_model=DuelResponse)
+async def accept_duel(duel_id: str, user_id: str = Depends(get_current_user)):
+    """Accepts a challenge and opens the window.
+
+    Raises:
+        HTTPException: 409 if the caller may not accept -- not theirs to
+            answer, already answered, or lapsed.
+    """
+    duel = await _visible_duel(duel_id, user_id)
+    if not duel.may_accept(user_id, datetime.now(UTC)):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="This challenge can no longer be accepted",
+        )
+    accepted = await offload(get_duel_operations().accept, duel)
+    if accepted is None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="This challenge can no longer be accepted",
+        )
+    return _response(accepted)
+
+
+@router.post("/{duel_id}/decline", response_model=DuelResponse)
+async def decline_duel(duel_id: str, user_id: str = Depends(get_current_user)):
+    """Refuses a challenge.
+
+    Raises:
+        HTTPException: 409 if it is not the caller's to refuse, or no longer
+            pending.
+    """
+    duel = await _visible_duel(duel_id, user_id)
+    if not duel.may_decline(user_id, datetime.now(UTC)):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="This challenge can no longer be declined",
+        )
+    declined = await offload(get_duel_operations().decline, duel)
+    if declined is None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="This challenge can no longer be declined",
+        )
+    return _response(declined)
+
+
+@router.delete("/{duel_id}", response_model=DuelResponse)
+async def cancel_duel(duel_id: str, user_id: str = Depends(get_current_user)):
+    """Withdraws a challenge the opponent has not answered.
+
+    Raises:
+        HTTPException: 409 once it has been accepted -- an active duel is
+            played out, not taken back.
+    """
+    duel = await _visible_duel(duel_id, user_id)
+    if not duel.may_cancel(user_id):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Only a pending challenge can be withdrawn",
+        )
+    cancelled = await offload(get_duel_operations().cancel, duel)
+    if cancelled is None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Only a pending challenge can be withdrawn",
+        )
+    return _response(cancelled)

--- a/backend/activity-backend/routes/leaderboard_routes.py
+++ b/backend/activity-backend/routes/leaderboard_routes.py
@@ -19,6 +19,7 @@ from routes.competition_models import (
 )
 from services.leaderboard_operations import (
     DEFAULT_LIMIT,
+    FRIENDS_SCOPE,
     GLOBAL_SCOPE,
     MAX_LIMIT,
     get_leaderboard_operations,
@@ -33,21 +34,21 @@ def _scope(value: str) -> str:
     """Validates a scope.
 
     Args:
-        value: `'global'` or an ISO 3166-1 alpha-2 code.
+        value: `'global'`, `'friends'`, or an ISO 3166-1 alpha-2 code.
 
     Returns:
         The scope, upper-cased when it is a country.
 
     Raises:
-        HTTPException: 422 if it is neither.
+        HTTPException: 422 if it is none of those.
     """
-    if value == GLOBAL_SCOPE:
+    if value in (GLOBAL_SCOPE, FRIENDS_SCOPE):
         return value
     if len(value) == 2 and value.isalpha():
         return value.upper()
     raise HTTPException(
         status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-        detail="scope must be 'global' or a two-letter country code",
+        detail="scope must be 'global', 'friends' or a two-letter country code",
     )
 
 
@@ -104,12 +105,17 @@ async def current_board(
     metric: Metric = Query(Metric.VERTICAL),
     scope: str = Query(GLOBAL_SCOPE),
     limit: int = Query(DEFAULT_LIMIT, ge=1, le=MAX_LIMIT),
-    _: str = Depends(get_current_user),
+    user_id: str = Depends(get_current_user),
 ):
-    """This week's live board, best first."""
+    """This week's live board, best first.
+
+    `scope=friends` ranks the caller against the people they mutually
+    follow. That is the board the Challenge button lives on, because a duel
+    needs a mutual follow to be offered at all.
+    """
     resolved = _scope(scope)
     operations = get_leaderboard_operations()
-    rows = await offload(operations.top, metric, resolved, None, limit)
+    rows = await offload(operations.top, metric, resolved, None, limit, user_id)
     return LeaderboardResponse(
         metric=metric,
         scope=resolved,

--- a/backend/activity-backend/routes/leaderboard_routes.py
+++ b/backend/activity-backend/routes/leaderboard_routes.py
@@ -1,0 +1,119 @@
+"""Leaderboard reads.
+
+The board shows a name, a total and a rank. It never links to an activity,
+which is what lets an activity with `private` visibility count towards a
+total without leaking anything about itself.
+"""
+
+import logging
+from datetime import UTC, date, datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from domain.competition.metrics import Metric, week_start
+from middleware.auth import get_current_user
+from routes.competition_models import (
+    LeaderboardEntry,
+    LeaderboardPlacing,
+    LeaderboardResponse,
+)
+from services.leaderboard_operations import (
+    DEFAULT_LIMIT,
+    GLOBAL_SCOPE,
+    MAX_LIMIT,
+    get_leaderboard_operations,
+)
+from services.offload import offload
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/v1/leaderboard", tags=["leaderboard"])
+
+
+def _scope(value: str) -> str:
+    """Validates a scope.
+
+    Args:
+        value: `'global'` or an ISO 3166-1 alpha-2 code.
+
+    Returns:
+        The scope, upper-cased when it is a country.
+
+    Raises:
+        HTTPException: 422 if it is neither.
+    """
+    if value == GLOBAL_SCOPE:
+        return value
+    if len(value) == 2 and value.isalpha():
+        return value.upper()
+    raise HTTPException(
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        detail="scope must be 'global' or a two-letter country code",
+    )
+
+
+@router.get("/me", response_model=LeaderboardPlacing)
+async def my_placing(
+    metric: Metric = Query(Metric.VERTICAL),
+    scope: str = Query(GLOBAL_SCOPE),
+    user_id: str = Depends(get_current_user),
+):
+    """Where the caller stands this week.
+
+    Separate from the board because someone in eight-thousandth place still
+    has to see their own position, and paging to it is not an option.
+    """
+    resolved = _scope(scope)
+    operations = get_leaderboard_operations()
+    placing = await offload(operations.placing, user_id, metric, resolved)
+    return LeaderboardPlacing(
+        metric=metric,
+        scope=resolved,
+        week_start=week_start(datetime.now(UTC)).isoformat(),
+        rank=placing["rank"] if placing else None,
+        value=placing["value"] if placing else 0.0,
+    )
+
+
+@router.get("/weeks/{week}", response_model=LeaderboardResponse)
+async def settled_week(
+    week: date,
+    metric: Metric = Query(Metric.VERTICAL),
+    scope: str = Query(GLOBAL_SCOPE),
+    limit: int = Query(DEFAULT_LIMIT, ge=1, le=MAX_LIMIT),
+    _: str = Depends(get_current_user),
+):
+    """A finished week, read back from the snapshot.
+
+    Empty for a week that was never settled, which includes every week
+    before this feature shipped.
+    """
+    resolved = _scope(scope)
+    operations = get_leaderboard_operations()
+    rows = await offload(operations.week, week, metric, resolved, limit)
+    return LeaderboardResponse(
+        metric=metric,
+        scope=resolved,
+        week_start=week.isoformat(),
+        settled=True,
+        entries=[LeaderboardEntry(**row) for row in rows],
+    )
+
+
+@router.get("", response_model=LeaderboardResponse)
+async def current_board(
+    metric: Metric = Query(Metric.VERTICAL),
+    scope: str = Query(GLOBAL_SCOPE),
+    limit: int = Query(DEFAULT_LIMIT, ge=1, le=MAX_LIMIT),
+    _: str = Depends(get_current_user),
+):
+    """This week's live board, best first."""
+    resolved = _scope(scope)
+    operations = get_leaderboard_operations()
+    rows = await offload(operations.top, metric, resolved, None, limit)
+    return LeaderboardResponse(
+        metric=metric,
+        scope=resolved,
+        week_start=week_start(datetime.now(UTC)).isoformat(),
+        settled=False,
+        entries=[LeaderboardEntry(**row) for row in rows],
+    )

--- a/backend/activity-backend/services/duel_operations.py
+++ b/backend/activity-backend/services/duel_operations.py
@@ -1,0 +1,415 @@
+"""Creating, answering and settling duels.
+
+Orchestration only: which transitions are legal and who won are decided in
+`domain/competition/duel.py`. This module does the reads and writes that
+follow, and enforces the same rules a second time as conditions on the
+update -- the database is what makes them true under concurrency, the
+domain is what makes them readable.
+
+Design: docs/superpowers/specs/2026-09-02-duel-and-leaderboard-design.md
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from postgrest import CountMethod
+from shared.follow_graph import follows_each_other
+
+from domain.competition.duel import (
+    INVITE_TTL,
+    Duel,
+    DuelStatus,
+    resolve_winner,
+)
+from domain.competition.metrics import Duration, Metric, duel_window
+
+logger = logging.getLogger(__name__)
+
+#: A duel list is a screen, not an archive.
+DEFAULT_LIMIT = 20
+MAX_LIMIT = 50
+
+#: How many past results the profile badge shows.
+RECENT_FORM = 5
+
+_operations: DuelOperations | None = None
+
+
+class NotEligible(Exception):
+    """The two accounts do not follow each other."""
+
+
+class DuelInProgress(Exception):
+    """A pending or active duel already stands between the two."""
+
+
+def initialize_duel_operations(client) -> DuelOperations:
+    """Binds the module singleton to a configured Supabase client."""
+    global _operations
+    _operations = DuelOperations(client)
+    return _operations
+
+
+def get_duel_operations() -> DuelOperations:
+    """The initialized singleton.
+
+    Raises:
+        RuntimeError: If startup did not initialize it.
+    """
+    if _operations is None:
+        raise RuntimeError(
+            "Duel operations not initialized. Call initialize_duel_operations() at startup."
+        )
+    return _operations
+
+
+class DuelOperations:
+    """Persistence for duels, plus the scoring read they settle on."""
+
+    _COLUMNS = (
+        "id,challenger_id,opponent_id,metric,duration,status,starts_at,"
+        "ends_at,challenger_value,opponent_value,winner_id,created_at,settled_at"
+    )
+
+    def __init__(self, client) -> None:
+        self._client = client
+
+    # ------------------------------------------------------------------
+    # Reads
+    # ------------------------------------------------------------------
+    def get(self, duel_id: str) -> Duel | None:
+        """One duel, or `None` if it does not exist."""
+        try:
+            response = (
+                self._client.table("duels")
+                .select(self._COLUMNS)
+                .eq("id", duel_id)
+                .limit(1)
+                .execute()
+            )
+        except Exception as exception:
+            logger.exception("Failed to read duel %s: %s", duel_id, exception)
+            return None
+        rows = getattr(response, "data", None)
+        return Duel.from_row(rows[0]) if isinstance(rows, list) and rows else None
+
+    def list_for(
+        self,
+        user_id: str,
+        status: DuelStatus | None = None,
+        limit: int = DEFAULT_LIMIT,
+        offset: int = 0,
+    ) -> list[Duel]:
+        """This user's duels, newest first.
+
+        Args:
+            user_id: Whose duels to list.
+            status: Narrow to one status, or `None` for all of them.
+            limit: Rows to return, capped at `MAX_LIMIT`.
+            offset: Rows to skip.
+
+        Returns:
+            Duels in which `user_id` is a player. Empty on a failed read.
+        """
+        capped = min(limit, MAX_LIMIT)
+        try:
+            query = (
+                self._client.table("duels")
+                .select(self._COLUMNS)
+                .or_(f"challenger_id.eq.{user_id},opponent_id.eq.{user_id}")
+                .order("created_at", desc=True)
+                .range(offset, offset + capped - 1)
+            )
+            if status is not None:
+                query = query.eq("status", str(status))
+            response = query.execute()
+        except Exception as exception:
+            logger.exception("Failed to list duels for %s: %s", user_id, exception)
+            return []
+        rows = getattr(response, "data", None)
+        return [Duel.from_row(row) for row in rows] if isinstance(rows, list) else []
+
+    def record(self, user_id: str) -> dict[str, Any]:
+        """Win/loss/draw counts and the last few results.
+
+        Derived rather than stored. A counter table would need a write on
+        every settlement and would drift the first time one failed.
+        """
+        finished = self._count(user_id, extra=None)
+        wins = self._count(user_id, extra=("winner_id", user_id))
+        draws = self._count(user_id, extra=("winner_id", None))
+        return {
+            "wins": wins,
+            "losses": max(finished - wins - draws, 0),
+            "draws": draws,
+            "recent": self._recent(user_id),
+        }
+
+    def score(self, user_id: str, metric: Metric, start: datetime, end: datetime) -> float:
+        """One player's score over one window.
+
+        Reads every activity in the window, not only the ones published to
+        the leaderboard: the opponent is a friend, and a private match
+        should not require publishing anything.
+
+        Returns:
+            The metric's comparable value -- higher wins, for all of them.
+            Zero on a failed read, which loses rather than inventing a
+            score.
+        """
+        try:
+            response = self._client.rpc(
+                "activity_total",
+                {
+                    "p_user": user_id,
+                    "p_metric": str(metric),
+                    "p_start": start.isoformat(),
+                    "p_end": end.isoformat(),
+                },
+            ).execute()
+        except Exception as exception:
+            logger.exception("activity_total failed for %s: %s", user_id, exception)
+            return 0.0
+        data = getattr(response, "data", None)
+        return float(data) if isinstance(data, int | float) else 0.0
+
+    # ------------------------------------------------------------------
+    # Writes
+    # ------------------------------------------------------------------
+    def create(
+        self,
+        challenger_id: str,
+        opponent_id: str,
+        metric: Metric,
+        duration: Duration,
+    ) -> Duel:
+        """Offers a challenge.
+
+        Args:
+            challenger_id: Who is challenging.
+            opponent_id: Who is being challenged.
+            metric: What the duel measures.
+            duration: How long the window runs once accepted.
+
+        Returns:
+            The pending duel. `starts_at` and `ends_at` are null until it is
+            accepted -- that is what keeps the window non-retroactive.
+
+        Raises:
+            NotEligible: The two do not follow each other.
+            DuelInProgress: A pending or active duel already stands.
+            RuntimeError: The write failed.
+        """
+        if not follows_each_other(self._client, challenger_id, opponent_id):
+            raise NotEligible
+
+        payload = {
+            "challenger_id": challenger_id,
+            "opponent_id": opponent_id,
+            "metric": str(metric),
+            "duration": str(duration),
+            "status": str(DuelStatus.PENDING),
+        }
+        try:
+            response = self._client.table("duels").insert(payload).execute()
+        except Exception as exception:
+            # `duels_one_live_per_pair` is the only unique constraint an
+            # insert can hit, and it is the one worth naming for the caller.
+            if _is_unique_violation(exception):
+                raise DuelInProgress from exception
+            raise
+        rows = getattr(response, "data", None)
+        if not (isinstance(rows, list) and rows):
+            raise RuntimeError("Duel insert returned no row")
+        return Duel.from_row(rows[0])
+
+    def accept(self, duel: Duel, now: datetime | None = None) -> Duel | None:
+        """Starts the window.
+
+        The update is conditional on the duel still being pending, so two
+        taps -- or two replicas -- cannot start it twice with two different
+        windows.
+
+        Returns:
+            The active duel, or `None` if it was no longer pending.
+        """
+        moment = now or datetime.now(UTC)
+        starts_at, ends_at = duel_window(duel.duration, moment)
+        return self._transition(
+            duel.id,
+            DuelStatus.PENDING,
+            {
+                "status": str(DuelStatus.ACTIVE),
+                "starts_at": starts_at.isoformat(),
+                "ends_at": ends_at.isoformat(),
+            },
+        )
+
+    def decline(self, duel: Duel) -> Duel | None:
+        """Refuses a challenge. Terminal: it is not re-opened later."""
+        return self._transition(duel.id, DuelStatus.PENDING, {"status": str(DuelStatus.DECLINED)})
+
+    def cancel(self, duel: Duel) -> Duel | None:
+        """Withdraws a challenge the opponent has not answered."""
+        return self._transition(duel.id, DuelStatus.PENDING, {"status": str(DuelStatus.CANCELLED)})
+
+    def settle(self, duel: Duel) -> Duel | None:
+        """Scores a closed window and writes the result.
+
+        Conditional on the duel still being active, so a lazy settlement on
+        read and the background sweep can race harmlessly: the loser of that
+        race writes nothing.
+
+        Returns:
+            The finished duel, or `None` if someone else settled it first.
+        """
+        if duel.starts_at is None or duel.ends_at is None:
+            logger.error("Duel %s is active with no window", duel.id)
+            return None
+
+        challenger = self.score(duel.challenger_id, duel.metric, duel.starts_at, duel.ends_at)
+        opponent = self.score(duel.opponent_id, duel.metric, duel.starts_at, duel.ends_at)
+        return self._transition(
+            duel.id,
+            DuelStatus.ACTIVE,
+            {
+                "status": str(DuelStatus.FINISHED),
+                "challenger_value": challenger,
+                "opponent_value": opponent,
+                "winner_id": resolve_winner(duel, challenger, opponent),
+                "settled_at": datetime.now(UTC).isoformat(),
+            },
+        )
+
+    def settle_due(self, now: datetime) -> int:
+        """Settles every duel whose window has closed.
+
+        Returns:
+            How many were settled.
+        """
+        settled = 0
+        for duel in self._due(now):
+            if self.settle(duel) is not None:
+                settled += 1
+        return settled
+
+    def expire_stale(self, now: datetime) -> int:
+        """Expires challenges nobody answered inside `INVITE_TTL`.
+
+        An unanswered invitation is not harmless: it holds the pair's one
+        live-duel slot, so the two of them cannot start a different duel
+        until it clears.
+
+        Returns:
+            How many were expired.
+        """
+        cutoff = (now - INVITE_TTL).isoformat()
+        try:
+            response = (
+                self._client.table("duels")
+                .update({"status": str(DuelStatus.EXPIRED)})
+                .eq("status", str(DuelStatus.PENDING))
+                .lte("created_at", cutoff)
+                .execute()
+            )
+        except Exception as exception:
+            logger.exception("Failed to expire stale duels: %s", exception)
+            return 0
+        rows = getattr(response, "data", None)
+        return len(rows) if isinstance(rows, list) else 0
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+    def _transition(
+        self, duel_id: str, expected: DuelStatus, fields: dict[str, Any]
+    ) -> Duel | None:
+        try:
+            response = (
+                self._client.table("duels")
+                .update(fields)
+                .eq("id", duel_id)
+                .eq("status", str(expected))
+                .execute()
+            )
+        except Exception as exception:
+            logger.exception("Failed to update duel %s: %s", duel_id, exception)
+            return None
+        rows = getattr(response, "data", None)
+        return Duel.from_row(rows[0]) if isinstance(rows, list) and rows else None
+
+    def _due(self, now: datetime) -> list[Duel]:
+        try:
+            response = (
+                self._client.table("duels")
+                .select(self._COLUMNS)
+                .eq("status", str(DuelStatus.ACTIVE))
+                .lte("ends_at", now.isoformat())
+                .order("ends_at")
+                .limit(MAX_LIMIT)
+                .execute()
+            )
+        except Exception as exception:
+            logger.exception("Failed to list due duels: %s", exception)
+            return []
+        rows = getattr(response, "data", None)
+        return [Duel.from_row(row) for row in rows] if isinstance(rows, list) else []
+
+    def _count(self, user_id: str, extra: tuple[str, str | None] | None) -> int:
+        try:
+            query = (
+                self._client.table("duels")
+                .select("id", count=CountMethod.exact)
+                .eq("status", str(DuelStatus.FINISHED))
+                .or_(f"challenger_id.eq.{user_id},opponent_id.eq.{user_id}")
+                .limit(1)
+            )
+            if extra is not None:
+                column, value = extra
+                query = query.is_(column, "null") if value is None else query.eq(column, value)
+            response = query.execute()
+        except Exception as exception:
+            logger.exception("Failed to count duels for %s: %s", user_id, exception)
+            return 0
+        return getattr(response, "count", 0) or 0
+
+    def _recent(self, user_id: str) -> list[str]:
+        try:
+            response = (
+                self._client.table("duels")
+                .select("winner_id,settled_at")
+                .eq("status", str(DuelStatus.FINISHED))
+                .or_(f"challenger_id.eq.{user_id},opponent_id.eq.{user_id}")
+                .order("settled_at", desc=True)
+                .limit(RECENT_FORM)
+                .execute()
+            )
+        except Exception as exception:
+            logger.exception("Failed to read recent form for %s: %s", user_id, exception)
+            return []
+        rows = getattr(response, "data", None)
+        if not isinstance(rows, list):
+            return []
+        return [_outcome(row.get("winner_id"), user_id) for row in rows]
+
+
+def _outcome(winner_id: str | None, user_id: str) -> str:
+    if winner_id is None:
+        return "D"
+    return "W" if str(winner_id) == user_id else "L"
+
+
+def _is_unique_violation(exception: Exception) -> bool:
+    """Whether a PostgREST error is Postgres' 23505.
+
+    The client wraps the error rather than typing it, so the code is read
+    off whichever attribute this version exposes.
+    """
+    code = getattr(exception, "code", None)
+    if code is None:
+        details = getattr(exception, "args", None)
+        code = details[0].get("code") if details and isinstance(details[0], dict) else None
+    return str(code) == "23505"

--- a/backend/activity-backend/services/duel_operations.py
+++ b/backend/activity-backend/services/duel_operations.py
@@ -148,6 +148,43 @@ class DuelOperations:
             "recent": self._recent(user_id),
         }
 
+    def players(self, duels: list[Duel]) -> dict[str, dict[str, Any]]:
+        """Display fields for everyone in `duels`, in one round trip.
+
+        A duel row shows the other player's name and picture. Fetching that
+        per card is the N+1 that takes down a list screen, so it is fetched
+        per page instead.
+
+        Returns:
+            User id to `{display_name, username, avatar_url}`. Missing ids
+            simply do not appear; the caller falls back to a placeholder.
+        """
+        ids = sorted({duel.challenger_id for duel in duels} | {duel.opponent_id for duel in duels})
+        if not ids:
+            return {}
+        try:
+            response = (
+                self._client.table("profiles")
+                .select("id,full_name,username,avatar_url")
+                .in_("id", ids)
+                .execute()
+            )
+        except Exception as exception:
+            logger.exception("Failed to read duel players: %s", exception)
+            return {}
+        rows = getattr(response, "data", None)
+        if not isinstance(rows, list):
+            return {}
+        return {
+            str(row["id"]): {
+                "display_name": row.get("full_name") or row.get("username") or "Skier",
+                "username": row.get("username"),
+                "avatar_url": row.get("avatar_url"),
+            }
+            for row in rows
+            if row.get("id")
+        }
+
     def score(self, user_id: str, metric: Metric, start: datetime, end: datetime) -> float:
         """One player's score over one window.
 

--- a/backend/activity-backend/services/duel_operations.py
+++ b/backend/activity-backend/services/duel_operations.py
@@ -25,6 +25,7 @@ from domain.competition.duel import (
     resolve_winner,
 )
 from domain.competition.metrics import Duration, Metric, duel_window
+from services.leaderboard_operations import display_fields
 
 logger = logging.getLogger(__name__)
 
@@ -155,17 +156,21 @@ class DuelOperations:
         per card is the N+1 that takes down a list screen, so it is fetched
         per page instead.
 
+        Reads `user_info`, not `profiles`: that table is empty and stays
+        empty, so a name taken from it would always be the placeholder.
+
         Returns:
-            User id to `{display_name, username, avatar_url}`. Missing ids
-            simply do not appear; the caller falls back to a placeholder.
+            User id to `{display_name, username, avatar_url, country_code}`.
+            Missing ids simply do not appear; the caller falls back to a
+            placeholder.
         """
         ids = sorted({duel.challenger_id for duel in duels} | {duel.opponent_id for duel in duels})
         if not ids:
             return {}
         try:
             response = (
-                self._client.table("profiles")
-                .select("id,full_name,username,avatar_url")
+                self._client.table("user_info")
+                .select("id,first_name,last_name,email")
                 .in_("id", ids)
                 .execute()
             )
@@ -175,15 +180,7 @@ class DuelOperations:
         rows = getattr(response, "data", None)
         if not isinstance(rows, list):
             return {}
-        return {
-            str(row["id"]): {
-                "display_name": row.get("full_name") or row.get("username") or "Skier",
-                "username": row.get("username"),
-                "avatar_url": row.get("avatar_url"),
-            }
-            for row in rows
-            if row.get("id")
-        }
+        return {str(row["id"]): display_fields(row) for row in rows if row.get("id")}
 
     def score(self, user_id: str, metric: Metric, start: datetime, end: datetime) -> float:
         """One player's score over one window.

--- a/backend/activity-backend/services/leaderboard_operations.py
+++ b/backend/activity-backend/services/leaderboard_operations.py
@@ -1,0 +1,285 @@
+"""Reading and settling the global leaderboard.
+
+Orchestration only. Every rule this module relies on -- which column a
+metric reads, where a week starts, why speed is inverted -- lives in
+`domain/competition/metrics.py` or in the SQL functions that mirror it.
+
+Design: docs/superpowers/specs/2026-09-02-duel-and-leaderboard-design.md
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, date, datetime
+from typing import Any
+
+from domain.competition.metrics import Metric, week_bounds, week_start
+
+logger = logging.getLogger(__name__)
+
+GLOBAL_SCOPE = "global"
+
+#: A board page. Deep paging into a leaderboard is not a use anyone has;
+#: someone looking for their own row uses `placing` instead.
+DEFAULT_LIMIT = 50
+MAX_LIMIT = 100
+
+#: How far down each weekly snapshot is kept. Past this, a placing is not
+#: something anyone displays, and the table grows for nothing.
+SNAPSHOT_DEPTH = 100
+
+_operations: LeaderboardOperations | None = None
+
+
+def initialize_leaderboard_operations(client) -> LeaderboardOperations:
+    """Binds the module singleton to a configured Supabase client."""
+    global _operations
+    _operations = LeaderboardOperations(client)
+    return _operations
+
+
+def get_leaderboard_operations() -> LeaderboardOperations:
+    """The initialized singleton.
+
+    Raises:
+        RuntimeError: If startup did not initialize it.
+    """
+    if _operations is None:
+        raise RuntimeError(
+            "Leaderboard operations not initialized. "
+            "Call initialize_leaderboard_operations() at startup."
+        )
+    return _operations
+
+
+class LeaderboardOperations:
+    """Board reads and the weekly snapshot write."""
+
+    _PROFILE_COLUMNS = "id,full_name,username,avatar_url,country_code"
+
+    def __init__(self, client) -> None:
+        self._client = client
+
+    def top(
+        self,
+        metric: Metric,
+        scope: str,
+        moment: datetime | None = None,
+        limit: int = DEFAULT_LIMIT,
+    ) -> list[dict[str, Any]]:
+        """The live board for the week containing `moment`.
+
+        Args:
+            metric: What the board measures.
+            scope: `GLOBAL_SCOPE` or an ISO-2 country code.
+            moment: Any instant in the week to read. Defaults to now.
+            limit: Rows to return, capped at `MAX_LIMIT`.
+
+        Returns:
+            Rows of `{rank, user_id, value, display_name, avatar_url}`,
+            already ordered. Empty when nobody has opted in this week, and
+            empty on a failed read -- a board that shows stale or partial
+            standings is worse than one that shows none.
+        """
+        start, end = week_bounds(moment or datetime.now(UTC))
+        rows = self._rank(metric, scope, start, end, min(limit, MAX_LIMIT))
+        return self._with_profiles(rows)
+
+    def placing(
+        self,
+        user_id: str,
+        metric: Metric,
+        scope: str,
+        moment: datetime | None = None,
+    ) -> dict[str, Any] | None:
+        """Where one user stands, however deep in the board they are.
+
+        Returns:
+            `{rank, value}`, or `None` when they have not placed -- no
+            opted-in activity in the window, or nothing the metric can read.
+        """
+        start, end = week_bounds(moment or datetime.now(UTC))
+        try:
+            response = self._client.rpc(
+                "leaderboard_placing",
+                {
+                    "p_user": user_id,
+                    "p_metric": str(metric),
+                    "p_scope": scope,
+                    "p_start": start.isoformat(),
+                    "p_end": end.isoformat(),
+                },
+            ).execute()
+        except Exception as exception:
+            logger.exception("leaderboard_placing failed: %s", exception)
+            return None
+        data = getattr(response, "data", None)
+        return data[0] if isinstance(data, list) and data else None
+
+    def week(
+        self,
+        week: date,
+        metric: Metric,
+        scope: str,
+        limit: int = DEFAULT_LIMIT,
+    ) -> list[dict[str, Any]]:
+        """A settled week, read back from the snapshot.
+
+        Returns:
+            The same row shape as `top`. Empty when that week was never
+            settled -- before this feature shipped, or a week with nobody in
+            it.
+        """
+        try:
+            response = (
+                self._client.table("leaderboard_weeks")
+                .select("rank,user_id,value")
+                .eq("week_start", week.isoformat())
+                .eq("metric", str(metric))
+                .eq("scope", scope)
+                .order("rank")
+                .limit(min(limit, MAX_LIMIT))
+                .execute()
+            )
+        except Exception as exception:
+            logger.exception("Failed to read week %s: %s", week, exception)
+            return []
+        rows = getattr(response, "data", None)
+        return self._with_profiles(rows if isinstance(rows, list) else [])
+
+    def settle_week(self, moment: datetime) -> int:
+        """Writes the snapshot for the week containing `moment`.
+
+        Idempotent: the rows are upserted on the snapshot's primary key, so
+        a second run -- another replica, a restart mid-sweep -- overwrites
+        rather than duplicates.
+
+        Args:
+            moment: Any instant in the week being settled.
+
+        Returns:
+            How many rows were written, across every metric and scope.
+        """
+        start, end = week_bounds(moment)
+        week = week_start(moment)
+        written = 0
+        for scope in [GLOBAL_SCOPE, *self._scopes(start, end)]:
+            for metric in Metric:
+                rows = self._rank(metric, scope, start, end, SNAPSHOT_DEPTH)
+                if rows:
+                    written += self._upsert_snapshot(week, metric, scope, rows)
+        logger.info("Settled week %s: %d rows", week, written)
+        return written
+
+    def _rank(
+        self,
+        metric: Metric,
+        scope: str,
+        start: datetime,
+        end: datetime,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        try:
+            response = self._client.rpc(
+                "leaderboard_top",
+                {
+                    "p_metric": str(metric),
+                    "p_scope": scope,
+                    "p_start": start.isoformat(),
+                    "p_end": end.isoformat(),
+                    "p_limit": limit,
+                },
+            ).execute()
+        except Exception as exception:
+            logger.exception("leaderboard_top failed: %s", exception)
+            return []
+        data = getattr(response, "data", None)
+        return data if isinstance(data, list) else []
+
+    def _scopes(self, start: datetime, end: datetime) -> list[str]:
+        try:
+            response = self._client.rpc(
+                "leaderboard_scopes",
+                {"p_start": start.isoformat(), "p_end": end.isoformat()},
+            ).execute()
+        except Exception as exception:
+            logger.exception("leaderboard_scopes failed: %s", exception)
+            return []
+        data = getattr(response, "data", None)
+        if not isinstance(data, list):
+            return []
+        return [row["scope"] for row in data if row.get("scope")]
+
+    def _upsert_snapshot(
+        self,
+        week: date,
+        metric: Metric,
+        scope: str,
+        rows: list[dict[str, Any]],
+    ) -> int:
+        payload = [
+            {
+                "week_start": week.isoformat(),
+                "metric": str(metric),
+                "scope": scope,
+                "rank": row["rank"],
+                "user_id": row["user_id"],
+                "value": row["value"],
+            }
+            for row in rows
+        ]
+        try:
+            self._client.table("leaderboard_weeks").upsert(payload).execute()
+        except Exception as exception:
+            logger.exception("Failed to snapshot %s/%s: %s", metric, scope, exception)
+            return 0
+        return len(payload)
+
+    def _with_profiles(self, rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Attaches display fields in one round trip, not one per row."""
+        if not rows:
+            return []
+        ids = [row["user_id"] for row in rows if row.get("user_id")]
+        profiles = self._profiles(ids)
+        return [
+            {
+                "rank": row["rank"],
+                "user_id": row["user_id"],
+                "value": row["value"],
+                **_display(profiles.get(row["user_id"], {})),
+            }
+            for row in rows
+        ]
+
+    def _profiles(self, ids: list[str]) -> dict[str, dict[str, Any]]:
+        if not ids:
+            return {}
+        try:
+            response = (
+                self._client.table("profiles")
+                .select(self._PROFILE_COLUMNS)
+                .in_("id", ids)
+                .execute()
+            )
+        except Exception as exception:
+            logger.exception("Failed to read board profiles: %s", exception)
+            return {}
+        data = getattr(response, "data", None)
+        if not isinstance(data, list):
+            return {}
+        return {str(row["id"]): row for row in data if row.get("id")}
+
+
+def _display(profile: dict[str, Any]) -> dict[str, Any]:
+    """The public half of a profile, for a board row.
+
+    A board shows a name, a picture and a country. It never shows an
+    activity, which is what lets a private activity count towards a total
+    without leaking anything about itself.
+    """
+    return {
+        "display_name": profile.get("full_name") or profile.get("username") or "Skier",
+        "username": profile.get("username"),
+        "avatar_url": profile.get("avatar_url"),
+        "country_code": profile.get("country_code"),
+    }

--- a/backend/activity-backend/services/leaderboard_operations.py
+++ b/backend/activity-backend/services/leaderboard_operations.py
@@ -20,6 +20,11 @@ logger = logging.getLogger(__name__)
 GLOBAL_SCOPE = "global"
 FRIENDS_SCOPE = "friends"
 
+#: Shown for a user with no name and no email handle. One placeholder, used
+#: by the board and by duel cards, so an unknown player reads the same way in
+#: both places.
+UNKNOWN_PLAYER = "Skier"
+
 #: A board page. Deep paging into a leaderboard is not a use anyone has;
 #: someone looking for their own row uses `placing` instead.
 DEFAULT_LIMIT = 50
@@ -56,7 +61,11 @@ def get_leaderboard_operations() -> LeaderboardOperations:
 class LeaderboardOperations:
     """Board reads and the weekly snapshot write."""
 
-    _PROFILE_COLUMNS = "id,full_name,username,avatar_url,country_code"
+    # `user_info`, not `profiles`. That table is empty and stays empty:
+    # `profiles.id` references Supabase auth's users while registration
+    # writes `user_info`, so create_profile fails with 23503 every time.
+    # main-backend renders profiles from `user_info` for the same reason.
+    _USER_COLUMNS = "id,first_name,last_name,email,country_code"
 
     def __init__(self, client) -> None:
         self._client = client
@@ -260,7 +269,7 @@ class LeaderboardOperations:
                 "rank": row["rank"],
                 "user_id": row["user_id"],
                 "value": row["value"],
-                **_display(profiles.get(row["user_id"], {})),
+                **display_fields(profiles.get(row["user_id"], {})),
             }
             for row in rows
         ]
@@ -270,10 +279,7 @@ class LeaderboardOperations:
             return {}
         try:
             response = (
-                self._client.table("profiles")
-                .select(self._PROFILE_COLUMNS)
-                .in_("id", ids)
-                .execute()
+                self._client.table("user_info").select(self._USER_COLUMNS).in_("id", ids).execute()
             )
         except Exception as exception:
             logger.exception("Failed to read board profiles: %s", exception)
@@ -284,16 +290,29 @@ class LeaderboardOperations:
         return {str(row["id"]): row for row in data if row.get("id")}
 
 
-def _display(profile: dict[str, Any]) -> dict[str, Any]:
-    """The public half of a profile, for a board row.
+def display_fields(user: dict[str, Any]) -> dict[str, Any]:
+    """The public half of a user, for a board row or a duel card.
 
-    A board shows a name, a picture and a country. It never shows an
-    activity, which is what lets a private activity count towards a total
-    without leaking anything about itself.
+    A board shows a name and a country. It never shows an activity, which is
+    what lets a private activity count towards a total without leaking
+    anything about itself.
+
+    Name, then email handle, then a placeholder -- the same ladder the follow
+    request list already uses, so one person is named the same way in both.
+
+    ponytail: avatar_url is always null. Uploaded avatars are written to
+    `profiles.avatar_url`, and that row never exists, so no avatar URL is
+    persisted anywhere in this database. Fill it in when profiles is
+    repaired; do not invent a second place to keep it.
     """
+    first = (user.get("first_name") or "").strip()
+    last = (user.get("last_name") or "").strip()
+    full = " ".join(part for part in (first, last) if part)
+    email = (user.get("email") or "").strip()
+    handle = email.split("@")[0] if "@" in email else None
     return {
-        "display_name": profile.get("full_name") or profile.get("username") or "Skier",
-        "username": profile.get("username"),
-        "avatar_url": profile.get("avatar_url"),
-        "country_code": profile.get("country_code"),
+        "display_name": full or handle or UNKNOWN_PLAYER,
+        "username": handle,
+        "avatar_url": None,
+        "country_code": user.get("country_code"),
     }

--- a/backend/activity-backend/services/leaderboard_operations.py
+++ b/backend/activity-backend/services/leaderboard_operations.py
@@ -18,6 +18,7 @@ from domain.competition.metrics import Metric, week_bounds, week_start
 logger = logging.getLogger(__name__)
 
 GLOBAL_SCOPE = "global"
+FRIENDS_SCOPE = "friends"
 
 #: A board page. Deep paging into a leaderboard is not a use anyone has;
 #: someone looking for their own row uses `placing` instead.
@@ -66,14 +67,18 @@ class LeaderboardOperations:
         scope: str,
         moment: datetime | None = None,
         limit: int = DEFAULT_LIMIT,
+        viewer_id: str | None = None,
     ) -> list[dict[str, Any]]:
         """The live board for the week containing `moment`.
 
         Args:
             metric: What the board measures.
-            scope: `GLOBAL_SCOPE` or an ISO-2 country code.
+            scope: `GLOBAL_SCOPE`, `FRIENDS_SCOPE`, or an ISO-2 country
+                code.
             moment: Any instant in the week to read. Defaults to now.
             limit: Rows to return, capped at `MAX_LIMIT`.
+            viewer_id: Required by `FRIENDS_SCOPE`, which is relative to
+                whoever is asking; ignored by the others.
 
         Returns:
             Rows of `{rank, user_id, value, display_name, avatar_url}`,
@@ -82,7 +87,7 @@ class LeaderboardOperations:
             standings is worse than one that shows none.
         """
         start, end = week_bounds(moment or datetime.now(UTC))
-        rows = self._rank(metric, scope, start, end, min(limit, MAX_LIMIT))
+        rows = self._rank(metric, scope, start, end, min(limit, MAX_LIMIT), viewer_id)
         return self._with_profiles(rows)
 
     def placing(
@@ -108,6 +113,10 @@ class LeaderboardOperations:
                     "p_scope": scope,
                     "p_start": start.isoformat(),
                     "p_end": end.isoformat(),
+                    # A friends board is relative to whoever is asking, and
+                    # the only person asking about their own placing is
+                    # themselves.
+                    "p_viewer": user_id,
                 },
             ).execute()
         except Exception as exception:
@@ -163,6 +172,9 @@ class LeaderboardOperations:
         start, end = week_bounds(moment)
         week = week_start(moment)
         written = 0
+        # Only boards that mean the same thing to everyone get snapshotted.
+        # A friends board is a different board per viewer, so there is no
+        # single week to write down.
         for scope in [GLOBAL_SCOPE, *self._scopes(start, end)]:
             for metric in Metric:
                 rows = self._rank(metric, scope, start, end, SNAPSHOT_DEPTH)
@@ -178,6 +190,7 @@ class LeaderboardOperations:
         start: datetime,
         end: datetime,
         limit: int,
+        viewer_id: str | None = None,
     ) -> list[dict[str, Any]]:
         try:
             response = self._client.rpc(
@@ -188,6 +201,7 @@ class LeaderboardOperations:
                     "p_start": start.isoformat(),
                     "p_end": end.isoformat(),
                     "p_limit": limit,
+                    "p_viewer": viewer_id,
                 },
             ).execute()
         except Exception as exception:

--- a/backend/activity-backend/services/leaderboard_operations.py
+++ b/backend/activity-backend/services/leaderboard_operations.py
@@ -302,8 +302,8 @@ def display_fields(user: dict[str, Any]) -> dict[str, Any]:
 
     ponytail: avatar_url is always null. Uploaded avatars are written to
     `profiles.avatar_url`, and that row never exists, so no avatar URL is
-    persisted anywhere in this database. Fill it in when profiles is
-    repaired; do not invent a second place to keep it.
+    persisted anywhere in this database -- issue #43. Fill it in when that is
+    fixed; do not invent a second place to keep it.
     """
     first = (user.get("first_name") or "").strip()
     last = (user.get("last_name") or "").strip()

--- a/backend/activity-backend/services/settlement_worker.py
+++ b/backend/activity-backend/services/settlement_worker.py
@@ -1,0 +1,87 @@
+"""Background settlement for duels and the weekly board.
+
+Rides the same lifespan pattern as `PipelineWorker`, which is the reason
+this feature needs no scheduler, no cron and no scheduled workflow.
+
+Every write it makes is idempotent, so running it on more than one replica
+is not a correctness problem: duel updates are conditional on the duel still
+being active, and snapshot rows are upserted on their primary key. The cost
+of a duplicate run is a wasted query, not a wrong result.
+
+Design: docs/superpowers/specs/2026-09-02-duel-and-leaderboard-design.md
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, date, datetime
+
+from domain.competition.metrics import week_start
+from services.duel_operations import get_duel_operations
+from services.leaderboard_operations import get_leaderboard_operations
+
+logger = logging.getLogger(__name__)
+
+#: A duel that ended is stale for at most this long, and a settled week
+#: appears at most this late. Both are read paths a user can also trigger
+#: directly, so the sweep is a backstop rather than the mechanism.
+SWEEP_SECONDS = 300
+
+
+class SettlementWorker:
+    """Closes finished duels, expires stale invitations, snapshots weeks."""
+
+    def __init__(self, interval_seconds: int = SWEEP_SECONDS) -> None:
+        self._interval = interval_seconds
+        self._running = False
+        # Which week has already been snapshotted by *this* process. A
+        # restart re-runs one snapshot, which the upsert absorbs.
+        self._last_settled_week: date | None = None
+
+    async def run_forever(self) -> None:
+        """Sweeps until `stop`.
+
+        One failed sweep must not end the loop -- the next one would settle
+        the same duels anyway, and a worker that dies on a transient
+        Supabase error silently stops settling for everyone.
+        """
+        self._running = True
+        logger.info("Settlement worker started interval=%ss", self._interval)
+        while self._running:
+            try:
+                await self.sweep(datetime.now(UTC))
+            except Exception:
+                logger.exception("Settlement sweep failed; continuing")
+            await asyncio.sleep(self._interval)
+
+    async def sweep(self, now: datetime) -> None:
+        """One pass: duels, then invitations, then the week just ended."""
+        duels = get_duel_operations()
+
+        settled = await asyncio.to_thread(duels.settle_due, now)
+        if settled:
+            logger.info("Settled %d duel(s)", settled)
+
+        expired = await asyncio.to_thread(duels.expire_stale, now)
+        if expired:
+            logger.info("Expired %d stale challenge(s)", expired)
+
+        await self._settle_finished_week(now)
+
+    async def _settle_finished_week(self, now: datetime) -> None:
+        """Snapshots the week that has just ended, once.
+
+        Deliberately settles the *previous* week: the current one is still
+        being skied, and a snapshot of it would be overwritten every sweep
+        for seven days.
+        """
+        current = week_start(now)
+        if self._last_settled_week == current:
+            return
+        previous = datetime.fromordinal(current.toordinal() - 1).replace(tzinfo=UTC)
+        await asyncio.to_thread(get_leaderboard_operations().settle_week, previous)
+        self._last_settled_week = current
+
+    def stop(self) -> None:
+        self._running = False

--- a/backend/activity-backend/services/supabase_client.py
+++ b/backend/activity-backend/services/supabase_client.py
@@ -251,14 +251,17 @@ class ActivitySupabaseClient:
         name: str | None = None,
         description: str | None = None,
         visibility: str | None = None,
+        on_leaderboard: bool | None = None,
     ) -> dict[str, Any] | None:
-        update_fields = {}
+        update_fields: dict[str, Any] = {}
         if name is not None:
             update_fields["name"] = name
         if description is not None:
             update_fields["description"] = description
         if visibility is not None:
             update_fields["visibility"] = visibility
+        if on_leaderboard is not None:
+            update_fields["on_leaderboard"] = on_leaderboard
         if not update_fields:
             return self.get_activity_by_id(activity_id)
 

--- a/backend/activity-backend/tests/conftest.py
+++ b/backend/activity-backend/tests/conftest.py
@@ -194,7 +194,15 @@ class StubActivityClient:
             return self._private_activity
         return None
 
-    def update_activity(self, activity_id, user_id, name=None, description=None, visibility=None):
+    def update_activity(
+        self,
+        activity_id,
+        user_id,
+        name=None,
+        description=None,
+        visibility=None,
+        on_leaderboard=None,
+    ):
         if activity_id != "activity-1":
             return None
         updated = dict(self._activity)
@@ -204,6 +212,8 @@ class StubActivityClient:
             updated["description"] = description
         if visibility is not None:
             updated["visibility"] = visibility
+        if on_leaderboard is not None:
+            updated["on_leaderboard"] = on_leaderboard
         return updated
 
     def delete_activity(self, activity_id, user_id):

--- a/backend/activity-backend/tests/test_competition_domain.py
+++ b/backend/activity-backend/tests/test_competition_domain.py
@@ -1,0 +1,148 @@
+"""Rules for scoring, windows and duel state.
+
+These construct values and call functions. No client, no fixture, no
+network -- which is the point of keeping the rules in `domain/`.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from domain.competition.duel import (
+    INVITE_TTL,
+    Duel,
+    DuelStatus,
+    can_transition,
+    resolve_winner,
+)
+from domain.competition.metrics import (
+    METRIC_COLUMNS,
+    Duration,
+    Metric,
+    duel_window,
+    score,
+    week_bounds,
+)
+
+# A Wednesday, so weekday arithmetic has somewhere to go in both directions.
+WEDNESDAY = datetime(2026, 9, 2, 14, 30, tzinfo=UTC)
+
+
+def _duel(**overrides) -> Duel:
+    base = {
+        "id": "duel-1",
+        "challenger_id": "alex",
+        "opponent_id": "jordan",
+        "metric": Metric.VERTICAL,
+        "duration": Duration.WEEK,
+        "status": DuelStatus.PENDING,
+        "created_at": WEDNESDAY,
+    }
+    return Duel(**{**base, **overrides})
+
+
+class TestScore:
+    def test_a_zero_pace_is_no_reading_not_infinite_speed(self):
+        # max_pace defaults to 0 in the schema. Treating that as the fastest
+        # run puts everyone who never recorded a speed at the top of the
+        # board.
+        assert score(Metric.SPEED, [0, 0, 0]) == 0.0
+
+    def test_top_speed_takes_the_smallest_positive_pace(self):
+        # 60 s/km is 60 km/h; 120 s/km is 30. Faster is the smaller pace.
+        assert score(Metric.SPEED, [120.0, 60.0, 0, None]) == pytest.approx(60.0)
+
+    def test_summed_metrics_ignore_missing_readings(self):
+        assert score(Metric.VERTICAL, [100.0, None, 250.5]) == pytest.approx(350.5)
+
+    def test_an_empty_window_scores_zero_for_every_metric(self):
+        assert all(score(metric, []) == 0.0 for metric in Metric)
+
+    def test_every_metric_names_a_column(self):
+        assert set(METRIC_COLUMNS) == set(Metric)
+
+
+class TestWindows:
+    def test_week_bounds_are_half_open_so_no_activity_lands_in_two_weeks(self):
+        start, end = week_bounds(WEDNESDAY)
+        next_start, _ = week_bounds(end)
+        assert end == next_start
+        assert start.weekday() == 0 and start.hour == 0
+
+    def test_today_ends_at_the_next_midnight_and_starts_now(self):
+        start, end = duel_window(Duration.TODAY, WEDNESDAY)
+        assert start == WEDNESDAY
+        assert end == datetime(2026, 9, 3, tzinfo=UTC)
+
+    def test_a_weekend_accepted_midweek_still_opens_on_friday(self):
+        # Otherwise "This Weekend" would quietly count Wednesday.
+        start, end = duel_window(Duration.WEEKEND, WEDNESDAY)
+        assert start == datetime(2026, 9, 4, tzinfo=UTC)
+        assert end == datetime(2026, 9, 7, tzinfo=UTC)
+
+    def test_a_weekend_accepted_on_saturday_opens_then_not_in_the_past(self):
+        saturday = datetime(2026, 9, 5, 9, 0, tzinfo=UTC)
+        start, _ = duel_window(Duration.WEEKEND, saturday)
+        assert start == saturday
+
+    def test_a_week_runs_seven_days_from_acceptance(self):
+        start, end = duel_window(Duration.WEEK, WEDNESDAY)
+        assert (start, end) == (WEDNESDAY, WEDNESDAY + timedelta(days=7))
+
+
+class TestDuelState:
+    def test_a_declined_duel_is_terminal(self):
+        assert not can_transition(DuelStatus.DECLINED, DuelStatus.ACTIVE)
+        assert not can_transition(DuelStatus.FINISHED, DuelStatus.ACTIVE)
+
+    def test_only_the_challenged_player_may_accept(self):
+        duel = _duel()
+        assert duel.may_accept("jordan", WEDNESDAY)
+        assert not duel.may_accept("alex", WEDNESDAY)
+        assert not duel.may_accept("stranger", WEDNESDAY)
+
+    def test_only_the_challenger_may_withdraw(self):
+        duel = _duel()
+        assert duel.may_cancel("alex")
+        assert not duel.may_cancel("jordan")
+
+    def test_a_lapsed_invitation_cannot_be_accepted(self):
+        duel = _duel()
+        assert not duel.may_accept("jordan", WEDNESDAY + INVITE_TTL)
+        assert duel.is_expired_at(WEDNESDAY + INVITE_TTL)
+
+    def test_an_active_duel_is_decidable_only_once_the_window_closes(self):
+        duel = _duel(
+            status=DuelStatus.ACTIVE,
+            starts_at=WEDNESDAY,
+            ends_at=WEDNESDAY + timedelta(days=7),
+        )
+        assert not duel.is_decidable_at(WEDNESDAY + timedelta(days=6))
+        assert duel.is_decidable_at(WEDNESDAY + timedelta(days=7))
+
+    def test_from_row_rejects_a_metric_this_version_cannot_score(self):
+        # A duel written by a newer deploy must not be settled by an older
+        # one guessing at the rule.
+        with pytest.raises(ValueError):
+            Duel.from_row(
+                {
+                    "id": "d",
+                    "challenger_id": "alex",
+                    "opponent_id": "jordan",
+                    "metric": "most_runs",
+                    "duration": "week",
+                    "status": "active",
+                    "created_at": WEDNESDAY.isoformat(),
+                }
+            )
+
+
+class TestWinner:
+    def test_the_higher_score_wins_for_every_metric(self):
+        duel = _duel()
+        assert resolve_winner(duel, 900.0, 120.0) == "alex"
+        assert resolve_winner(duel, 120.0, 900.0) == "jordan"
+
+    def test_two_players_who_recorded_nothing_draw(self):
+        # Not a loss for both: a draw writes no winner and no W and no L.
+        assert resolve_winner(_duel(), 0.0, 0.0) is None

--- a/backend/activity-backend/tests/test_competition_operations.py
+++ b/backend/activity-backend/tests/test_competition_operations.py
@@ -1,0 +1,323 @@
+"""Operations layer: the reads and writes around the competition rules.
+
+The client is faked rather than mocked per call, so each test can assert on
+the *shape* of what was sent -- which filters guard an update, how many round
+trips a board page costs -- instead of on a call count.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from domain.competition.duel import Duel, DuelStatus
+from domain.competition.metrics import Duration, Metric
+from services.duel_operations import DuelInProgress, DuelOperations, NotEligible
+from services.leaderboard_operations import GLOBAL_SCOPE, LeaderboardOperations
+
+NOW = datetime(2026, 9, 2, 12, 0, tzinfo=UTC)
+ALEX = "alex"
+JORDAN = "jordan"
+
+
+class _UniqueViolation(Exception):
+    code = "23505"
+
+
+class _Response:
+    def __init__(self, data, count=None):
+        self.data = data
+        self.count = count
+
+
+class _Query:
+    """Records what was asked, answers from the store."""
+
+    def __init__(self, store, table):
+        self._store = store
+        self.table = table
+        self.op = "select"
+        self.payload = None
+        self.filters: list[tuple] = []
+
+    def select(self, *_args, **_kwargs):
+        return self
+
+    def insert(self, payload):
+        self.op, self.payload = "insert", payload
+        return self
+
+    def update(self, payload):
+        self.op, self.payload = "update", payload
+        return self
+
+    def upsert(self, payload):
+        self.op, self.payload = "upsert", payload
+        return self
+
+    def eq(self, column, value):
+        self.filters.append(("eq", column, value))
+        return self
+
+    def is_(self, column, value):
+        self.filters.append(("is", column, value))
+        return self
+
+    def in_(self, column, values):
+        self.filters.append(("in", column, values))
+        return self
+
+    def or_(self, expression):
+        self.filters.append(("or", expression, None))
+        return self
+
+    def lte(self, column, value):
+        self.filters.append(("lte", column, value))
+        return self
+
+    def order(self, *_args, **_kwargs):
+        return self
+
+    def limit(self, *_args, **_kwargs):
+        return self
+
+    def range(self, *_args, **_kwargs):
+        return self
+
+    def execute(self):
+        self._store.calls.append(self)
+        if self.op == "insert" and self.table in self._store.insert_raises:
+            raise self._store.insert_raises[self.table]
+        if self.op == "insert":
+            return _Response([{**self._store.insert_defaults, **self.payload}])
+        if self.op in ("update", "upsert"):
+            rows = self._store.rows.get(self.table, [])
+            return _Response([{**row, **(self.payload or {})} for row in rows])
+        return _Response(
+            self._store.rows.get(self.table, []),
+            self._store.count_for(self),
+        )
+
+
+class _Deferred:
+    """supabase-py returns a builder from `rpc`; the call happens on
+    `execute`."""
+
+    def __init__(self, response):
+        self._response = response
+
+    def execute(self):
+        return self._response
+
+
+class _FakeClient:
+    def __init__(self):
+        self.rows: dict[str, list] = {}
+        # Answers a count query from its filters, so the three counts behind
+        # a W-L record can differ the way they do in Postgres.
+        self.count_for = lambda _query: 0
+        self.insert_raises: dict[str, Exception] = {}
+        self.insert_defaults: dict = {}
+        self.rpc_results: dict = {}
+        self.calls: list[_Query] = []
+        self.rpc_calls: list[tuple[str, dict]] = []
+
+    def table(self, name):
+        return _Query(self, name)
+
+    def rpc(self, name, params):
+        self.rpc_calls.append((name, params))
+        return _Deferred(_Response(self.rpc_results.get(name, [])))
+
+    def queries_on(self, table):
+        return [call for call in self.calls if call.table == table]
+
+
+def _mutual(client):
+    client.rows["follows"] = [
+        {"follower_id": ALEX, "followee_id": JORDAN},
+        {"follower_id": JORDAN, "followee_id": ALEX},
+    ]
+
+
+def _pending_duel(**overrides) -> Duel:
+    base = {
+        "id": "duel-1",
+        "challenger_id": ALEX,
+        "opponent_id": JORDAN,
+        "metric": Metric.VERTICAL,
+        "duration": Duration.WEEK,
+        "status": DuelStatus.PENDING,
+        "created_at": NOW,
+    }
+    return Duel(**{**base, **overrides})
+
+
+class TestEligibility:
+    def test_a_one_directional_follow_is_not_a_friendship(self):
+        client = _FakeClient()
+        client.rows["follows"] = [{"follower_id": ALEX, "followee_id": JORDAN}]
+
+        with pytest.raises(NotEligible):
+            DuelOperations(client).create(ALEX, JORDAN, Metric.VERTICAL, Duration.WEEK)
+
+    def test_a_failed_follow_read_refuses_the_challenge(self):
+        # Fails closed. An unreadable graph is not permission to duel.
+        client = _FakeClient()
+        client.rows["follows"] = "not-a-list"
+
+        with pytest.raises(NotEligible):
+            DuelOperations(client).create(ALEX, JORDAN, Metric.VERTICAL, Duration.WEEK)
+
+    def test_a_second_live_duel_is_a_conflict_not_a_crash(self):
+        client = _FakeClient()
+        _mutual(client)
+        client.insert_raises["duels"] = _UniqueViolation()
+
+        with pytest.raises(DuelInProgress):
+            DuelOperations(client).create(ALEX, JORDAN, Metric.VERTICAL, Duration.WEEK)
+
+    def test_a_challenge_starts_pending_with_no_window(self):
+        client = _FakeClient()
+        _mutual(client)
+        client.insert_defaults = {"id": "duel-1", "created_at": NOW.isoformat()}
+
+        duel = DuelOperations(client).create(ALEX, JORDAN, Metric.SPEED, Duration.TODAY)
+
+        assert duel.status is DuelStatus.PENDING
+        assert duel.starts_at is None and duel.ends_at is None
+
+
+class TestTransitions:
+    def test_accepting_is_conditional_on_still_being_pending(self):
+        # Two taps, or two replicas, must not open two different windows.
+        client = _FakeClient()
+        client.rows["duels"] = [_row()]
+
+        DuelOperations(client).accept(_pending_duel(), NOW)
+
+        update = client.queries_on("duels")[-1]
+        assert ("eq", "status", "pending") in update.filters
+        assert update.payload["status"] == "active"
+        assert update.payload["starts_at"] == NOW.isoformat()
+
+    def test_settling_is_conditional_on_still_being_active(self):
+        client = _FakeClient()
+        client.rows["duels"] = [_row(status="active")]
+        client.rpc_results["activity_total"] = 0
+
+        duel = _pending_duel(
+            status=DuelStatus.ACTIVE,
+            starts_at=NOW,
+            ends_at=NOW + timedelta(days=1),
+        )
+        DuelOperations(client).settle(duel)
+
+        update = client.queries_on("duels")[-1]
+        assert ("eq", "status", "active") in update.filters
+
+    def test_two_equal_totals_settle_as_a_draw(self):
+        client = _FakeClient()
+        client.rows["duels"] = [_row(status="active")]
+        # Both players read the same total, which is the case worth pinning:
+        # a tie writes no winner rather than defaulting to the challenger.
+        client.rpc_results["activity_total"] = 900.0
+
+        duel = _pending_duel(
+            status=DuelStatus.ACTIVE,
+            starts_at=NOW,
+            ends_at=NOW + timedelta(days=1),
+        )
+        DuelOperations(client).settle(duel)
+
+        payload = client.queries_on("duels")[-1].payload
+        assert payload["winner_id"] is None
+        assert payload["challenger_value"] == payload["opponent_value"] == 900.0
+
+    def test_a_duel_scores_every_activity_not_only_published_ones(self):
+        # activity_total has no on_leaderboard filter, and must not grow one:
+        # a private match should not require publishing anything.
+        client = _FakeClient()
+        client.rpc_results["activity_total"] = 12.5
+
+        DuelOperations(client).score(ALEX, Metric.DISTANCE, NOW, NOW + timedelta(days=1))
+
+        name, params = client.rpc_calls[-1]
+        assert name == "activity_total"
+        assert params["p_metric"] == "distance"
+
+
+class TestRecord:
+    def test_losses_are_what_is_left_after_wins_and_draws(self):
+        # Losses are not counted, they are inferred. Ten finished, four won,
+        # one drawn, so five lost.
+        client = _FakeClient()
+
+        def counts(query):
+            columns = {column for _, column, _ in query.filters}
+            if "winner_id" not in columns:
+                return 10
+            drawn = ("is", "winner_id", "null") in query.filters
+            return 1 if drawn else 4
+
+        client.count_for = counts
+
+        record = DuelOperations(client).record(ALEX)
+
+        assert (record["wins"], record["draws"], record["losses"]) == (4, 1, 5)
+
+    def test_a_drawn_duel_reads_as_d_not_as_a_loss(self):
+        client = _FakeClient()
+        client.rows["duels"] = [
+            {"winner_id": None, "settled_at": NOW.isoformat()},
+            {"winner_id": ALEX, "settled_at": NOW.isoformat()},
+            {"winner_id": JORDAN, "settled_at": NOW.isoformat()},
+        ]
+
+        assert DuelOperations(client).record(ALEX)["recent"] == ["D", "W", "L"]
+
+
+class TestLeaderboard:
+    def test_a_board_page_costs_one_profile_query_not_one_per_row(self):
+        client = _FakeClient()
+        client.rpc_results["leaderboard_top"] = [
+            {"rank": index, "user_id": f"user-{index}", "value": 100.0 - index}
+            for index in range(1, 26)
+        ]
+        client.rows["profiles"] = []
+
+        entries = LeaderboardOperations(client).top(Metric.VERTICAL, GLOBAL_SCOPE, NOW)
+
+        assert len(entries) == 25
+        assert len(client.queries_on("profiles")) == 1
+
+    def test_the_board_window_is_the_monday_of_that_week(self):
+        client = _FakeClient()
+        LeaderboardOperations(client).top(Metric.SPEED, GLOBAL_SCOPE, NOW)
+
+        _, params = client.rpc_calls[-1]
+        assert params["p_start"].startswith("2026-08-31")
+        assert params["p_end"].startswith("2026-09-07")
+
+    def test_a_snapshot_carries_the_keys_it_is_upserted_on(self):
+        client = _FakeClient()
+        client.rpc_results["leaderboard_top"] = [{"rank": 1, "user_id": ALEX, "value": 900.0}]
+        client.rpc_results["leaderboard_scopes"] = []
+
+        LeaderboardOperations(client).settle_week(NOW)
+
+        upsert = client.queries_on("leaderboard_weeks")[0]
+        assert upsert.op == "upsert"
+        assert upsert.payload[0]["week_start"] == "2026-08-31"
+        assert {"week_start", "metric", "scope", "rank"} <= set(upsert.payload[0])
+
+
+def _row(status="pending"):
+    return {
+        "id": "duel-1",
+        "challenger_id": ALEX,
+        "opponent_id": JORDAN,
+        "metric": "vertical",
+        "duration": "week",
+        "status": status,
+        "created_at": NOW.isoformat(),
+    }

--- a/backend/activity-backend/tests/test_competition_operations.py
+++ b/backend/activity-backend/tests/test_competition_operations.py
@@ -321,3 +321,31 @@ def _row(status="pending"):
         "status": status,
         "created_at": NOW.isoformat(),
     }
+
+
+class TestScopes:
+    def test_a_friends_board_is_relative_to_whoever_is_asking(self):
+        # Without the viewer the SQL cannot resolve "friends" at all, and a
+        # board that silently fell back to global would show strangers a
+        # Challenge button they cannot use.
+        client = _FakeClient()
+
+        LeaderboardOperations(client).top(Metric.VERTICAL, "friends", NOW, 50, viewer_id=ALEX)
+
+        _, params = client.rpc_calls[-1]
+        assert params["p_scope"] == "friends"
+        assert params["p_viewer"] == ALEX
+
+    def test_a_friends_board_is_never_snapshotted(self):
+        # It is a different board per viewer, so there is no single week to
+        # write down.
+        client = _FakeClient()
+        client.rpc_results["leaderboard_top"] = [{"rank": 1, "user_id": ALEX, "value": 900.0}]
+        client.rpc_results["leaderboard_scopes"] = [{"scope": "CH"}]
+
+        LeaderboardOperations(client).settle_week(NOW)
+
+        scopes = {
+            params["p_scope"] for name, params in client.rpc_calls if name == "leaderboard_top"
+        }
+        assert scopes == {GLOBAL_SCOPE, "CH"}

--- a/backend/activity-backend/tests/test_competition_operations.py
+++ b/backend/activity-backend/tests/test_competition_operations.py
@@ -277,18 +277,48 @@ class TestRecord:
 
 
 class TestLeaderboard:
-    def test_a_board_page_costs_one_profile_query_not_one_per_row(self):
+    def test_a_board_page_costs_one_name_query_not_one_per_row(self):
         client = _FakeClient()
         client.rpc_results["leaderboard_top"] = [
             {"rank": index, "user_id": f"user-{index}", "value": 100.0 - index}
             for index in range(1, 26)
         ]
-        client.rows["profiles"] = []
+        client.rows["user_info"] = []
 
         entries = LeaderboardOperations(client).top(Metric.VERTICAL, GLOBAL_SCOPE, NOW)
 
         assert len(entries) == 25
-        assert len(client.queries_on("profiles")) == 1
+        assert len(client.queries_on("user_info")) == 1
+        # `profiles` is empty in this database and always will be; reading it
+        # would name every skier "Skier".
+        assert client.queries_on("profiles") == []
+
+    def test_a_board_row_names_a_user_from_user_info(self):
+        client = _FakeClient()
+        client.rpc_results["leaderboard_top"] = [{"rank": 1, "user_id": ALEX, "value": 900.0}]
+        client.rows["user_info"] = [
+            {
+                "id": ALEX,
+                "first_name": "Alpha",
+                "last_name": "Tester",
+                "email": "alpha@example.com",
+                "country_code": "CH",
+            }
+        ]
+
+        entry = LeaderboardOperations(client).top(Metric.VERTICAL, GLOBAL_SCOPE, NOW)[0]
+
+        assert entry["display_name"] == "Alpha Tester"
+        assert entry["country_code"] == "CH"
+
+    def test_a_nameless_user_falls_back_to_their_email_handle(self):
+        client = _FakeClient()
+        client.rpc_results["leaderboard_top"] = [{"rank": 1, "user_id": ALEX, "value": 900.0}]
+        client.rows["user_info"] = [{"id": ALEX, "email": "skier@example.com"}]
+
+        entry = LeaderboardOperations(client).top(Metric.VERTICAL, GLOBAL_SCOPE, NOW)[0]
+
+        assert entry["display_name"] == "skier"
 
     def test_the_board_window_is_the_monday_of_that_week(self):
         client = _FakeClient()

--- a/backend/activity-backend/tests/test_duel_routes.py
+++ b/backend/activity-backend/tests/test_duel_routes.py
@@ -1,0 +1,111 @@
+"""Duel routes, through the app.
+
+These exist because the unit tests did not catch a real bug: `_response`
+took an optional `players` map, two handlers never passed one, and the
+duels they returned had null names. Nothing failed -- a null name renders
+as a blank. The route is the only layer where that is visible.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+import services.duel_operations as duel_operations
+from domain.competition.duel import Duel, DuelStatus
+from domain.competition.metrics import Duration, Metric
+
+NOW = datetime(2026, 9, 2, 12, 0, tzinfo=UTC)
+
+
+def _duel(status=DuelStatus.PENDING, **overrides) -> Duel:
+    base = {
+        "id": "duel-1",
+        "challenger_id": "sam",
+        "opponent_id": "user-1",
+        "metric": Metric.VERTICAL,
+        "duration": Duration.WEEK,
+        "status": status,
+        "created_at": NOW,
+    }
+    return Duel(**{**base, **overrides})
+
+
+class _StubOperations:
+    """Enough of DuelOperations to answer a route."""
+
+    def __init__(self, duels, players):
+        self._duels = duels
+        self._players = players
+        self.player_calls = 0
+
+    def list_for(self, user_id, status=None, limit=20, offset=0):
+        return self._duels
+
+    def get(self, duel_id):
+        return next((d for d in self._duels if d.id == duel_id), None)
+
+    def players(self, duels):
+        self.player_calls += 1
+        return self._players
+
+    def accept(self, duel, now=None):
+        return _duel(status=DuelStatus.ACTIVE, starts_at=NOW, ends_at=NOW)
+
+
+@pytest.fixture
+def stub(monkeypatch):
+    def install(duels, players):
+        operations = _StubOperations(duels, players)
+        monkeypatch.setattr(duel_operations, "_operations", operations)
+        return operations
+
+    return install
+
+
+NAMED = {
+    "sam": {"display_name": "Sam Park", "avatar_url": None, "username": "sampark"},
+    "user-1": {"display_name": "You", "avatar_url": None, "username": "you"},
+}
+
+
+def test_a_listed_duel_names_both_players(client, stub):
+    stub([_duel()], NAMED)
+
+    body = client.get("/api/v1/duels").json()
+
+    assert body["items"][0]["challenger_name"] == "Sam Park"
+    assert body["items"][0]["opponent_name"] == "You"
+
+
+def test_a_page_of_duels_reads_profiles_once(client, stub):
+    operations = stub([_duel(), _duel(id="duel-2")], NAMED)
+
+    client.get("/api/v1/duels")
+
+    assert operations.player_calls == 1
+
+
+def test_a_player_with_no_profile_row_still_has_a_name(client, stub):
+    # The row is created lazily, so a real player can have none. A blank
+    # where the name goes is worse than a placeholder.
+    stub([_duel()], {})
+
+    body = client.get("/api/v1/duels").json()
+
+    assert body["items"][0]["challenger_name"] == "Skier"
+    assert body["items"][0]["opponent_name"] == "Skier"
+
+
+def test_answering_a_duel_returns_it_named(client, stub):
+    stub([_duel()], NAMED)
+
+    body = client.post("/api/v1/duels/duel-1/accept").json()
+
+    assert body["status"] == "active"
+    assert body["challenger_name"] == "Sam Park"
+
+
+def test_someone_elses_duel_is_not_found_rather_than_forbidden(client, stub):
+    stub([_duel(challenger_id="a", opponent_id="b")], NAMED)
+
+    assert client.get("/api/v1/duels/duel-1").status_code == 404

--- a/backend/db/migrations/019_duels_and_leaderboard.sql
+++ b/backend/db/migrations/019_duels_and_leaderboard.sql
@@ -1,0 +1,97 @@
+-- Run this in the Supabase SQL editor after 018. Purely additive: two
+-- columns, two tables, three indexes. Nothing existing changes shape, so
+-- deployed code that predates this migration keeps working.
+--
+-- Design: docs/superpowers/specs/2026-09-02-duel-and-leaderboard-design.md
+
+begin;
+
+-- Per-activity opt-in for the global board. Default false so nothing joins
+-- the leaderboard by accident -- an activity is published to a ranking only
+-- because its owner said so, one activity at a time.
+alter table activities
+  add column if not exists on_leaderboard boolean not null default false;
+
+-- Partial: the board only ever reads opted-in rows, and the index stays the
+-- size of that subset rather than the size of `activities`. start_time
+-- leads because every board query is a window, and user_id follows because
+-- every board query groups by it.
+create index if not exists activities_leaderboard_idx
+  on activities (start_time desc, user_id)
+  where on_leaderboard;
+
+-- ISO 3166-1 alpha-2, chosen by the user. Null means they have not picked
+-- one and appear on the global board only. Inferring this from GPS would
+-- reclassify anyone who takes a single trip abroad.
+alter table profiles
+  add column if not exists country_code char(2);
+
+-- user_stats.week_start rolls over and the previous week's numbers are gone
+-- with it, so the board's history has to be written down before that
+-- happens. Top 100 per metric per scope: enough for "who won last week" and
+-- for a trophy, bounded at a few thousand rows a year.
+create table if not exists leaderboard_weeks (
+  week_start date not null,
+  metric     text not null,
+  scope      text not null,
+  rank       int  not null,
+  user_id    uuid not null references user_info(id) on delete cascade,
+  value      double precision not null,
+  primary key (week_start, metric, scope, rank),
+  constraint leaderboard_weeks_metric_check
+    check (metric in ('vertical', 'speed', 'distance')),
+  constraint leaderboard_weeks_rank_check check (rank >= 1)
+);
+
+-- Reading one week's board is the only access pattern; the primary key
+-- already serves it. This index serves the other one: "where did I place".
+create index if not exists leaderboard_weeks_user_idx
+  on leaderboard_weeks (user_id, week_start desc);
+
+create table if not exists duels (
+  id                uuid primary key default gen_random_uuid(),
+  challenger_id     uuid not null references user_info(id) on delete cascade,
+  opponent_id       uuid not null references user_info(id) on delete cascade,
+  metric            text not null,
+  duration          text not null,
+  status            text not null default 'pending',
+  -- Written when the challenge is accepted, never before. That is what
+  -- makes a window non-retroactive: neither player can bank a head start
+  -- by choosing when to send the challenge.
+  starts_at         timestamptz,
+  ends_at           timestamptz,
+  challenger_value  double precision,
+  opponent_value    double precision,
+  -- Null while unfinished, and also null on a draw. settled_at is what
+  -- distinguishes the two.
+  winner_id         uuid references user_info(id) on delete set null,
+  created_at        timestamptz not null default now(),
+  settled_at        timestamptz,
+  constraint duels_metric_check
+    check (metric in ('vertical', 'speed', 'distance')),
+  constraint duels_duration_check
+    check (duration in ('today', 'weekend', 'week')),
+  constraint duels_status_check
+    check (status in ('pending', 'active', 'finished',
+                      'declined', 'cancelled', 'expired')),
+  constraint duels_distinct_players check (challenger_id <> opponent_id)
+);
+
+-- One live duel per pair, in either direction. least/greatest normalise the
+-- pair so that A challenging B and B challenging A collide on the same key
+-- rather than both being accepted.
+create unique index if not exists duels_one_live_per_pair
+  on duels (least(challenger_id, opponent_id),
+            greatest(challenger_id, opponent_id))
+  where status in ('pending', 'active');
+
+-- The two list queries: "my duels" and the settlement sweep.
+create index if not exists duels_participant_idx
+  on duels (challenger_id, created_at desc);
+create index if not exists duels_opponent_idx
+  on duels (opponent_id, created_at desc);
+create index if not exists duels_settlement_idx
+  on duels (ends_at)
+  where status = 'active';
+
+commit;

--- a/backend/db/migrations/020_leaderboard_functions.sql
+++ b/backend/db/migrations/020_leaderboard_functions.sql
@@ -1,0 +1,148 @@
+-- Run this in the Supabase SQL editor after 019. Three read-only functions,
+-- no schema change.
+--
+-- PostgREST cannot express a GROUP BY, and the alternative -- pulling every
+-- opted-in activity for the week into the service and folding it there --
+-- is an unbounded read that grows with the user base. The aggregate belongs
+-- next to the rows.
+--
+-- Every one of these mirrors a rule in
+-- activity-backend/domain/competition/metrics.py. The two must agree:
+--   * windows are half-open, [start, end)
+--   * speed is 3600 / smallest positive max_pace, in km/h, so that higher
+--     wins for every metric and one ORDER BY serves them all
+--   * a zero max_pace is a missing reading, not an infinite speed
+--
+-- Design: docs/superpowers/specs/2026-09-02-duel-and-leaderboard-design.md
+
+begin;
+
+-- One user's score over one window. The duel settler's whole read.
+create or replace function public.activity_total(
+  p_user uuid,
+  p_metric text,
+  p_start timestamptz,
+  p_end timestamptz
+) returns double precision
+language sql
+stable
+as $$
+  select coalesce(
+    case p_metric
+      when 'vertical' then sum(a.elevation_gain_meters)
+      when 'distance' then sum(a.distance_meters)
+      when 'speed'    then 3600.0 / nullif(min(nullif(a.max_pace, 0)), 0)
+    end,
+    0
+  )
+  from activities a
+  where a.user_id = p_user
+    and a.start_time >= p_start
+    and a.start_time <  p_end;
+$$;
+
+-- The board. `p_scope` is 'global' or an ISO-2 country code.
+--
+-- Note this reads `on_leaderboard`, which activity_total deliberately does
+-- not: a duel counts everything you skied, a board counts only what you
+-- chose to publish.
+create or replace function public.leaderboard_top(
+  p_metric text,
+  p_scope text,
+  p_start timestamptz,
+  p_end timestamptz,
+  p_limit int default 50
+) returns table (rank int, user_id uuid, value double precision)
+language sql
+stable
+as $$
+  select
+    row_number() over (order by t.value desc, t.user_id)::int as rank,
+    t.user_id,
+    t.value
+  from (
+    select
+      a.user_id,
+      case p_metric
+        when 'vertical' then sum(a.elevation_gain_meters)
+        when 'distance' then sum(a.distance_meters)
+        when 'speed'    then 3600.0 / nullif(min(nullif(a.max_pace, 0)), 0)
+      end as value
+    from activities a
+    left join profiles p on p.id = a.user_id
+    where a.on_leaderboard
+      and a.start_time >= p_start
+      and a.start_time <  p_end
+      and (p_scope = 'global' or p.country_code = p_scope)
+    group by a.user_id
+  ) t
+  -- A null value means the metric had nothing to read; a zero means the
+  -- user opted in and recorded nothing. Neither is a placing.
+  where t.value is not null and t.value > 0
+  order by t.value desc, t.user_id
+  limit least(p_limit, 100);
+$$;
+
+-- Where one user placed, whether or not they are on the page the client
+-- fetched. Someone ranked 8,000th still has to see their own position, and
+-- paging to find it is not an option.
+create or replace function public.leaderboard_placing(
+  p_user uuid,
+  p_metric text,
+  p_scope text,
+  p_start timestamptz,
+  p_end timestamptz
+) returns table (rank int, value double precision)
+language sql
+stable
+as $$
+  with totals as (
+    select
+      a.user_id,
+      case p_metric
+        when 'vertical' then sum(a.elevation_gain_meters)
+        when 'distance' then sum(a.distance_meters)
+        when 'speed'    then 3600.0 / nullif(min(nullif(a.max_pace, 0)), 0)
+      end as value
+    from activities a
+    left join profiles p on p.id = a.user_id
+    where a.on_leaderboard
+      and a.start_time >= p_start
+      and a.start_time <  p_end
+      and (p_scope = 'global' or p.country_code = p_scope)
+    group by a.user_id
+  ),
+  ranked as (
+    select
+      user_id,
+      value,
+      row_number() over (order by value desc, user_id)::int as rank
+    from totals
+    where value is not null and value > 0
+  )
+  select ranked.rank, ranked.value
+  from ranked
+  where ranked.user_id = p_user;
+$$;
+
+-- Which country boards actually exist for a window. The weekly settlement
+-- writes one snapshot per metric per scope, and without this it would have
+-- to guess -- either at a hardcoded country list or by reading every
+-- profile row.
+create or replace function public.leaderboard_scopes(
+  p_start timestamptz,
+  p_end timestamptz
+) returns table (scope text)
+language sql
+stable
+as $$
+  select distinct p.country_code::text
+  from activities a
+  join profiles p on p.id = a.user_id
+  where a.on_leaderboard
+    and a.start_time >= p_start
+    and a.start_time <  p_end
+    and p.country_code is not null;
+$$;
+
+commit;

--- a/backend/db/migrations/020_leaderboard_functions.sql
+++ b/backend/db/migrations/020_leaderboard_functions.sql
@@ -17,6 +17,41 @@
 
 begin;
 
+-- Which rows a scope admits. One definition, three callers -- the board, the
+-- placing and the snapshot must agree on who is on a board, and repeating
+-- this predicate three times is how they would stop agreeing.
+--
+-- ponytail: the friends clause is a correlated exists per grouped user. It
+-- is two indexed lookups on a two-column table; make it a join against a
+-- materialised mutual-follow set if the board gets slow.
+create or replace function public.leaderboard_in_scope(
+  p_scope text,
+  p_viewer uuid,
+  p_user uuid,
+  p_country char(2)
+) returns boolean
+language sql
+stable
+as $$
+  select case
+    when p_scope = 'global' then true
+    when p_scope = 'friends' then
+      p_viewer is not null and (
+        p_user = p_viewer
+        or exists (
+          select 1
+          from follows outbound
+          join follows inbound
+            on inbound.follower_id = outbound.followee_id
+           and inbound.followee_id = outbound.follower_id
+          where outbound.follower_id = p_viewer
+            and outbound.followee_id = p_user
+        )
+      )
+    else p_country = p_scope
+  end;
+$$;
+
 -- One user's score over one window. The duel settler's whole read.
 create or replace function public.activity_total(
   p_user uuid,
@@ -51,7 +86,8 @@ create or replace function public.leaderboard_top(
   p_scope text,
   p_start timestamptz,
   p_end timestamptz,
-  p_limit int default 50
+  p_limit int default 50,
+  p_viewer uuid default null
 ) returns table (rank int, user_id uuid, value double precision)
 language sql
 stable
@@ -73,7 +109,9 @@ as $$
     where a.on_leaderboard
       and a.start_time >= p_start
       and a.start_time <  p_end
-      and (p_scope = 'global' or p.country_code = p_scope)
+      and public.leaderboard_in_scope(
+            p_scope, p_viewer, a.user_id, p.country_code
+          )
     group by a.user_id
   ) t
   -- A null value means the metric had nothing to read; a zero means the
@@ -91,7 +129,8 @@ create or replace function public.leaderboard_placing(
   p_metric text,
   p_scope text,
   p_start timestamptz,
-  p_end timestamptz
+  p_end timestamptz,
+  p_viewer uuid default null
 ) returns table (rank int, value double precision)
 language sql
 stable
@@ -109,7 +148,9 @@ as $$
     where a.on_leaderboard
       and a.start_time >= p_start
       and a.start_time <  p_end
-      and (p_scope = 'global' or p.country_code = p_scope)
+      and public.leaderboard_in_scope(
+            p_scope, p_viewer, a.user_id, p.country_code
+          )
     group by a.user_id
   ),
   ranked as (

--- a/backend/db/migrations/021_competition_on_user_info.sql
+++ b/backend/db/migrations/021_competition_on_user_info.sql
@@ -13,8 +13,8 @@
 -- `activities.user_id` references and is therefore always present.
 --
 -- `profiles.country_code` from 019 is left in place rather than dropped. It
--- is unread and on an empty table; a drop buys nothing and a future profiles
--- repair may want it back. Nothing should write to it.
+-- is unread and on an empty table; a drop buys nothing and the profiles
+-- repair tracked in issue #43 may want it back. Nothing should write to it.
 
 begin;
 

--- a/backend/db/migrations/021_competition_on_user_info.sql
+++ b/backend/db/migrations/021_competition_on_user_info.sql
@@ -1,0 +1,152 @@
+-- Run this in the Supabase SQL editor after 020. Corrects which table the
+-- competition surfaces read.
+--
+-- 019 and 020 hung the country column and every display join off `profiles`.
+-- That table is empty and always will be: `profiles.id` carries a foreign key
+-- to Supabase auth's `users`, registration writes `user_info`, so every insert
+-- in main-backend's create_profile fails with 23503 and the row is never made.
+-- main-backend already works around this by rendering a profile from
+-- `user_info` at read time (see _profile_from_user_info in
+-- app/api/v1/users_profile_routes.py).
+--
+-- So the board and the duel cards read `user_info`, which is what
+-- `activities.user_id` references and is therefore always present.
+--
+-- `profiles.country_code` from 019 is left in place rather than dropped. It
+-- is unread and on an empty table; a drop buys nothing and a future profiles
+-- repair may want it back. Nothing should write to it.
+
+begin;
+
+-- ISO 3166-1 alpha-2, chosen by the user. Null means they have not picked one
+-- and appear on the global board only.
+alter table user_info
+  add column if not exists country_code char(2);
+
+create index if not exists user_info_country_idx
+  on user_info (country_code)
+  where country_code is not null;
+
+-- Same predicate as 020, unchanged. Restated only because the callers below
+-- are being replaced and they must all agree on who is on a board.
+create or replace function public.leaderboard_in_scope(
+  p_scope text,
+  p_viewer uuid,
+  p_user uuid,
+  p_country char(2)
+) returns boolean
+language sql
+stable
+as $$
+  select case
+    when p_scope = 'global' then true
+    when p_scope = 'friends' then
+      p_viewer is not null and (
+        p_user = p_viewer
+        or exists (
+          select 1
+          from follows outbound
+          join follows inbound
+            on inbound.follower_id = outbound.followee_id
+           and inbound.followee_id = outbound.follower_id
+          where outbound.follower_id = p_viewer
+            and outbound.followee_id = p_user
+        )
+      )
+    else p_country = p_scope
+  end;
+$$;
+
+create or replace function public.leaderboard_top(
+  p_metric text,
+  p_scope text,
+  p_start timestamptz,
+  p_end timestamptz,
+  p_limit int default 50,
+  p_viewer uuid default null
+) returns table (rank int, user_id uuid, value double precision)
+language sql
+stable
+as $$
+  select
+    row_number() over (order by t.value desc, t.user_id)::int as rank,
+    t.user_id,
+    t.value
+  from (
+    select
+      a.user_id,
+      case p_metric
+        when 'vertical' then sum(a.elevation_gain_meters)
+        when 'distance' then sum(a.distance_meters)
+        when 'speed'    then 3600.0 / nullif(min(nullif(a.max_pace, 0)), 0)
+      end as value
+    from activities a
+    join user_info u on u.id = a.user_id
+    where a.on_leaderboard
+      and a.start_time >= p_start
+      and a.start_time <  p_end
+      and public.leaderboard_in_scope(p_scope, p_viewer, a.user_id, u.country_code)
+    group by a.user_id
+  ) t
+  where t.value is not null and t.value > 0
+  order by t.value desc, t.user_id
+  limit least(p_limit, 100);
+$$;
+
+create or replace function public.leaderboard_placing(
+  p_user uuid,
+  p_metric text,
+  p_scope text,
+  p_start timestamptz,
+  p_end timestamptz,
+  p_viewer uuid default null
+) returns table (rank int, value double precision)
+language sql
+stable
+as $$
+  with totals as (
+    select
+      a.user_id,
+      case p_metric
+        when 'vertical' then sum(a.elevation_gain_meters)
+        when 'distance' then sum(a.distance_meters)
+        when 'speed'    then 3600.0 / nullif(min(nullif(a.max_pace, 0)), 0)
+      end as value
+    from activities a
+    join user_info u on u.id = a.user_id
+    where a.on_leaderboard
+      and a.start_time >= p_start
+      and a.start_time <  p_end
+      and public.leaderboard_in_scope(p_scope, p_viewer, a.user_id, u.country_code)
+    group by a.user_id
+  ),
+  ranked as (
+    select
+      user_id,
+      value,
+      row_number() over (order by value desc, user_id)::int as rank
+    from totals
+    where value is not null and value > 0
+  )
+  select ranked.rank, ranked.value
+  from ranked
+  where ranked.user_id = p_user;
+$$;
+
+create or replace function public.leaderboard_scopes(
+  p_start timestamptz,
+  p_end timestamptz
+) returns table (scope text)
+language sql
+stable
+as $$
+  select distinct u.country_code::text
+  from activities a
+  join user_info u on u.id = a.user_id
+  where a.on_leaderboard
+    and a.start_time >= p_start
+    and a.start_time <  p_end
+    and u.country_code is not null;
+$$;
+
+commit;

--- a/backend/main-backend/app/api/v1/users_profile_routes.py
+++ b/backend/main-backend/app/api/v1/users_profile_routes.py
@@ -53,6 +53,7 @@ def _profile_from_user_info(user_id: str) -> dict[str, Any] | None:
         "push_token": None,
         "ski_level": None,
         "home": None,
+        "country_code": None,
         # user_info.created_at is nullable even though it defaults to now().
         "created_at": user.get("created_at") or datetime.now(UTC),
         "updated_at": user.get("updated_at"),
@@ -174,6 +175,7 @@ def update_current_user_profile_endpoint(
             push_token=profile_update.push_token,
             ski_level=profile_update.ski_level,
             home=profile_update.home,
+            country_code=profile_update.country_code,
         )
         if updated_profile is None:
             raise HTTPException(

--- a/backend/main-backend/app/api/v1/users_profile_routes.py
+++ b/backend/main-backend/app/api/v1/users_profile_routes.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from app.api.dependencies import get_current_user
 from app.core.profile_cache import get_profile, invalidate_profile, set_profile
@@ -53,7 +53,9 @@ def _profile_from_user_info(user_id: str) -> dict[str, Any] | None:
         "push_token": None,
         "ski_level": None,
         "home": None,
-        "country_code": None,
+        # The one field on this fallback that is real: it lives on user_info,
+        # written by PUT /me/country. See migration 021.
+        "country_code": user.get("country_code"),
         # user_info.created_at is nullable even though it defaults to now().
         "created_at": user.get("created_at") or datetime.now(UTC),
         "updated_at": user.get("updated_at"),
@@ -175,7 +177,6 @@ def update_current_user_profile_endpoint(
             push_token=profile_update.push_token,
             ski_level=profile_update.ski_level,
             home=profile_update.home,
-            country_code=profile_update.country_code,
         )
         if updated_profile is None:
             raise HTTPException(
@@ -194,6 +195,44 @@ def update_current_user_profile_endpoint(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to update user profile",
         ) from None
+
+
+class CountrySetting(BaseModel):
+    """Which country leaderboard this account appears on."""
+
+    country_code: str | None = Field(
+        None,
+        min_length=2,
+        max_length=2,
+        description="ISO 3166-1 alpha-2, or null for the global board only",
+    )
+
+
+@router.put("/me/country", response_model=CountrySetting)
+def set_my_country(
+    setting: CountrySetting,
+    current_user: User = Depends(get_current_user),
+) -> CountrySetting:
+    """Choose the country leaderboard to appear on.
+
+    Its own route rather than a field on PUT /me/profile, for the same
+    reason /me/privacy is: that route writes `profiles`, which has no row
+    for anyone, so the value would be accepted and lost.
+
+    Null clears it -- the user then appears on the global board only. It is
+    read at query time, so a change takes effect on the next board read; no
+    backfill and nothing to invalidate beyond the profile cache.
+    """
+    _ensure_database_configured()
+
+    if not supabase_client.set_user_country(current_user.id, setting.country_code):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found",
+        ) from None
+
+    invalidate_profile(current_user.id)
+    return setting
 
 
 @router.get("/{user_id}/profile", response_model=ProfileResponse)

--- a/backend/main-backend/app/core/supabase/profiles.py
+++ b/backend/main-backend/app/core/supabase/profiles.py
@@ -159,7 +159,6 @@ class ProfileOperations(SupabaseBase):
         push_token: str | None = None,
         ski_level: str | None = None,
         home: str | None = None,
-        country_code: str | None = None,
     ) -> dict[str, Any] | None:
         """
         Update profile fields.
@@ -176,8 +175,6 @@ class ProfileOperations(SupabaseBase):
         - push_token: Optional[str], the push token of the user
         - ski_level: Optional[str], the ski level of the user
         - home: Optional[str], the home of the user
-        - country_code: Optional[str], ISO 3166-1 alpha-2, which
-          country leaderboard the user appears on
 
         Expected Return:
         - Optional[Dict[str, Any]]: the profile data for the user, or None if not found
@@ -207,10 +204,6 @@ class ProfileOperations(SupabaseBase):
             update_data["ski_level"] = ski_level
         if home is not None:
             update_data["home"] = home
-        if country_code is not None:
-            # Stored upper-case so the board's scope filter is an equality
-            # test rather than a case-insensitive one.
-            update_data["country_code"] = country_code.upper()
 
         if not update_data:
             logger.warning("No fields to update provided")

--- a/backend/main-backend/app/core/supabase/profiles.py
+++ b/backend/main-backend/app/core/supabase/profiles.py
@@ -159,6 +159,7 @@ class ProfileOperations(SupabaseBase):
         push_token: str | None = None,
         ski_level: str | None = None,
         home: str | None = None,
+        country_code: str | None = None,
     ) -> dict[str, Any] | None:
         """
         Update profile fields.
@@ -175,6 +176,8 @@ class ProfileOperations(SupabaseBase):
         - push_token: Optional[str], the push token of the user
         - ski_level: Optional[str], the ski level of the user
         - home: Optional[str], the home of the user
+        - country_code: Optional[str], ISO 3166-1 alpha-2, which
+          country leaderboard the user appears on
 
         Expected Return:
         - Optional[Dict[str, Any]]: the profile data for the user, or None if not found
@@ -204,6 +207,10 @@ class ProfileOperations(SupabaseBase):
             update_data["ski_level"] = ski_level
         if home is not None:
             update_data["home"] = home
+        if country_code is not None:
+            # Stored upper-case so the board's scope filter is an equality
+            # test rather than a case-insensitive one.
+            update_data["country_code"] = country_code.upper()
 
         if not update_data:
             logger.warning("No fields to update provided")

--- a/backend/main-backend/app/core/supabase/users.py
+++ b/backend/main-backend/app/core/supabase/users.py
@@ -164,6 +164,39 @@ class UserOperations(SupabaseBase):
             logger.exception(f"Failed to set is_private for user {id}: {exc}")
             return False
 
+    def set_user_country(self, id: str, country_code: str | None) -> bool:
+        """Set or clear which country leaderboard this user appears on.
+
+        Lives on `user_info` rather than `profiles` for the same reason
+        `is_private` does: `profiles.id` references Supabase auth's users,
+        registration writes `user_info`, so a profiles row is never created
+        and a value written there would be lost. See
+        backend/db/migrations/021_competition_on_user_info.sql.
+
+        Args:
+            id: The user.
+            country_code: ISO 3166-1 alpha-2, or None to leave the country
+                boards and appear only on the global one.
+
+        Returns:
+            True when a row was updated.
+        """
+        if not self.is_configured():
+            logger.warning("Supabase not configured; skipping set_user_country.")
+            return False
+        client = self._client
+        if client is None:
+            return False
+        # Stored upper-case so the board's scope filter is an equality test
+        # rather than a case-insensitive one.
+        value = country_code.upper() if country_code else None
+        try:
+            resp = client.table("user_info").update({"country_code": value}).eq("id", id).execute()
+            return bool(getattr(resp, "data", None))
+        except Exception as exc:
+            logger.exception(f"Failed to set country_code for user {id}: {exc}")
+            return False
+
     def email_exists(self, email: str) -> bool:
         """Check if email already exists in user_info table."""
         if not self.is_configured():

--- a/backend/main-backend/app/schemas/__init__.py
+++ b/backend/main-backend/app/schemas/__init__.py
@@ -78,6 +78,12 @@ class ProfileBase(BaseModel):
     push_token: str | None = None
     ski_level: str | None = None
     home: str | None = None
+    country_code: str | None = Field(
+        None,
+        min_length=2,
+        max_length=2,
+        description="ISO 3166-1 alpha-2, for the country leaderboard",
+    )
 
 
 class ProfileUpdate(BaseModel):
@@ -90,6 +96,12 @@ class ProfileUpdate(BaseModel):
     push_token: str | None = None
     ski_level: str | None = None
     home: str | None = None
+    country_code: str | None = Field(
+        None,
+        min_length=2,
+        max_length=2,
+        description="ISO 3166-1 alpha-2, for the country leaderboard",
+    )
 
 
 class ProfileResponse(BaseModel):
@@ -105,6 +117,12 @@ class ProfileResponse(BaseModel):
     push_token: str | None = None
     ski_level: str | None = None
     home: str | None = None
+    country_code: str | None = Field(
+        None,
+        min_length=2,
+        max_length=2,
+        description="ISO 3166-1 alpha-2, for the country leaderboard",
+    )
     created_at: datetime
     updated_at: datetime | None = None
 

--- a/backend/main-backend/app/schemas/__init__.py
+++ b/backend/main-backend/app/schemas/__init__.py
@@ -78,12 +78,6 @@ class ProfileBase(BaseModel):
     push_token: str | None = None
     ski_level: str | None = None
     home: str | None = None
-    country_code: str | None = Field(
-        None,
-        min_length=2,
-        max_length=2,
-        description="ISO 3166-1 alpha-2, for the country leaderboard",
-    )
 
 
 class ProfileUpdate(BaseModel):
@@ -96,12 +90,6 @@ class ProfileUpdate(BaseModel):
     push_token: str | None = None
     ski_level: str | None = None
     home: str | None = None
-    country_code: str | None = Field(
-        None,
-        min_length=2,
-        max_length=2,
-        description="ISO 3166-1 alpha-2, for the country leaderboard",
-    )
 
 
 class ProfileResponse(BaseModel):

--- a/backend/shared/follow_graph.py
+++ b/backend/shared/follow_graph.py
@@ -49,3 +49,50 @@ def following_ids(client, user_id: str) -> list[str]:
     except Exception as exception:
         logger.exception("Failed to list follows for %s: %s", user_id, exception)
         return []
+
+
+def follows_each_other(client, first_id: str, second_id: str) -> bool:
+    """Whether two accounts follow each other.
+
+    A duel is offered on a mutual follow, which is the closest thing this
+    schema has to a friendship. Reading it here rather than inventing a
+    second relationship keeps the privacy rule in one place: if the pair
+    cannot see each other's profile, they cannot duel.
+
+    One query for both directions -- the pair is small enough that two
+    `in_` filters beat two round trips.
+
+    Args:
+        client: A configured `supabase.Client`.
+        first_id: One account.
+        second_id: The other.
+
+    Returns:
+        True only when both edges exist. False on failure, which fails
+        closed: a challenge is refused rather than allowed on a bad read.
+    """
+    if not first_id or not second_id or first_id == second_id:
+        return False
+    pair = [first_id, second_id]
+    try:
+        response = (
+            client.table("follows")
+            .select("follower_id,followee_id")
+            .in_("follower_id", pair)
+            .in_("followee_id", pair)
+            .limit(4)
+            .execute()
+        )
+        data = getattr(response, "data", None)
+        if not isinstance(data, list):
+            return False
+        edges = {(row.get("follower_id"), row.get("followee_id")) for row in data}
+        return (first_id, second_id) in edges and (second_id, first_id) in edges
+    except Exception as exception:
+        logger.exception(
+            "Failed to check mutual follow between %s and %s: %s",
+            first_id,
+            second_id,
+            exception,
+        )
+        return False

--- a/docs/service-ownership.md
+++ b/docs/service-ownership.md
@@ -9,6 +9,7 @@ One specific backend for each service (activity-related, main-backend handling u
 - notifications: main-backend
 - weather: main-backend
 - activities: activity-backend
+- competition (duels, leaderboard): activity-backend
 - community (subthreads/posts/comments): community-backend
 - follows (social graph): community-backend
 
@@ -22,7 +23,7 @@ One specific backend for each service (activity-related, main-backend handling u
 
 - main-backend: /api/v1/auth, /api/v1/users, /api/v1/notifications, /api/v1/weather
   - notification is not yet being implemented
-- activity-backend: /api/v1/activities
+- activity-backend: /api/v1/activities, /api/v1/leaderboard, /api/v1/duels
 - community-backend: /api/subthreads, /api/posts, /api/comments, /api/v1/follows
 
 ## Migration Decision (2026-03-20)
@@ -66,6 +67,18 @@ activity list.
 An HTTP hop would put two more round trips — roughly 880ms — in front of
 every activity list, for one indexed read of a two-column table whose shape
 is settled. The read is allowed; a write from activity-backend is not.
+
+### activity-backend reads `follows` for duels (2026-09-02)
+
+The same exception, extended by one caller. A duel is offered on a mutual
+follow, so `DuelOperations.create` asks `shared.follow_graph` whether both
+edges exist before it writes anything.
+
+The alternative was to put duels in community-backend, which owns the graph.
+That service does not own `activities`, so every settlement — two players per
+duel — would become an HTTP call to activity-backend for a score. Scoring is
+the expensive half and the graph read is the cheap half, so the feature sits
+with the scores. Still read-only; the writes stay in community-backend.
 
 ## Future Direction
 

--- a/docs/service-ownership.md
+++ b/docs/service-ownership.md
@@ -80,6 +80,21 @@ duel — would become an HTTP call to activity-backend for a score. Scoring is
 the expensive half and the graph read is the cheap half, so the feature sits
 with the scores. Still read-only; the writes stay in community-backend.
 
+### activity-backend reads `user_info` (2026-09-02)
+
+main-backend owns users. activity-backend reads `user_info` to put a name on
+a leaderboard row and on a duel card.
+
+The obvious place for a display name is `profiles`, and it is the wrong one:
+that table is empty and stays empty, because `profiles.id` references
+Supabase auth's `users` while registration writes `user_info`. main-backend
+renders profiles from `user_info` at read time for exactly this reason.
+`user_info.country_code`, which decides the country boards, lives there for
+the same reason and is written only by `PUT /api/v1/users/me/country`.
+
+One `in_` read per page, never one per row. Read-only; the writes stay in
+main-backend.
+
 ## Future Direction
 
 If notification throughput or channel complexity grows, split notifications

--- a/docs/service-ownership.md
+++ b/docs/service-ownership.md
@@ -95,6 +95,10 @@ the same reason and is written only by `PUT /api/v1/users/me/country`.
 One `in_` read per page, never one per row. Read-only; the writes stay in
 main-backend.
 
+Repairing `profiles` is tracked in issue #43. If it lands, this read can move
+back to `profiles`; until then `user_info` is the only table with a name in
+it.
+
 ## Future Direction
 
 If notification throughput or channel complexity grows, split notifications

--- a/docs/superpowers/specs/2026-09-02-duel-and-leaderboard-design.md
+++ b/docs/superpowers/specs/2026-09-02-duel-and-leaderboard-design.md
@@ -56,9 +56,17 @@ over and the previous week's numbers are lost, so a snapshot is the only way
 past weeks survive. Storing every participant instead would grow at
 participants x 52 rows a year and need a retention policy.
 
-**Country is user-selected.** A new `country_code` on `profiles`, chosen in
-settings. Inferring it from GPS would reclassify a user who takes one trip
-abroad.
+**Country is user-selected.** A new `country_code` on `user_info`, chosen in
+settings and written by `PUT /api/v1/users/me/country`. Inferring it from GPS
+would reclassify a user who takes one trip abroad.
+
+It sits on `user_info`, not on `profiles`, and so does every display name the
+board and the duel cards read. `profiles` is empty and stays empty:
+`profiles.id` references Supabase auth's `users` while registration writes
+`user_info`, so main-backend's `create_profile` fails with 23503 every time
+and no row is ever made. main-backend already renders profiles from
+`user_info` at read time for the same reason. Migration 019 got this wrong;
+021 corrects it.
 
 **Three scopes, one predicate.** `global`, `friends` and a country code are
 decided by a single SQL function, `leaderboard_in_scope`, called by the
@@ -98,7 +106,8 @@ create index activities_leaderboard_idx
   where on_leaderboard;
 
 -- ISO 3166-1 alpha-2. Null means the user has not chosen; global board only.
-alter table profiles add column country_code char(2);
+-- On user_info, not profiles -- see the decision above.
+alter table user_info add column country_code char(2);
 
 -- Weekly settlement snapshot: top 100 per metric per scope.
 create table leaderboard_weeks (

--- a/docs/superpowers/specs/2026-09-02-duel-and-leaderboard-design.md
+++ b/docs/superpowers/specs/2026-09-02-duel-and-leaderboard-design.md
@@ -1,0 +1,386 @@
+# Duel and Leaderboard Design
+
+Status: approved, not yet implemented.
+Date: 2026-09-02.
+
+## Summary
+
+Two competition modes, one scoring primitive.
+
+1. **Global leaderboard** — an opt-in ranking. A user marks individual
+   activities as counting, and those activities are summed into a weekly
+   board, ranked globally and by country. The board settles every week and
+   the top 100 are kept.
+2. **Friend duel** — a 1v1 head-to-head between two users who follow each
+   other. They pick a metric and a duration; whoever's total is higher when
+   the window closes wins.
+
+Both reduce to the same query: sum one column of `activities` for one user
+over one time window. The leaderboard drops the user filter and adds
+`GROUP BY`. Everything else is packaging.
+
+## Decisions
+
+Each of these was chosen deliberately; the rejected alternative is named so a
+later reader does not re-litigate it.
+
+**Asynchronous, not live.** No WebSocket, no presence, no live GPS stream.
+Both players ski normally and upload as they already do. A live head-to-head
+would need realtime infrastructure the app does not have, and phone signal on
+a mountain makes it unreliable in exactly the moment it matters.
+
+**Leaderboard opt-in is per activity**, not per account. A user decides
+activity by activity whether it counts. The consequence is that `user_stats`
+cannot be the leaderboard source — it sums everything regardless — so the
+board aggregates `activities` directly.
+
+**Duels ignore the leaderboard opt-in.** A duel counts every activity in the
+window. The opponent is a friend, not the world; requiring a user to publish
+data to the global board in order to play a private match is the wrong trade.
+
+**Duel eligibility is mutual follow.** Both users follow each other. This
+reuses the existing `follows` table and the `can_read_account` gate, so it
+adds no new privacy surface and no new harassment vector.
+
+**Duel windows are non-retroactive and symmetric.** `starts_at` is written at
+the moment the challenge is accepted, for both players. `ends_at` is the
+calendar end of the chosen duration. Accepting "This Weekend" on Sunday gives
+both players one day — symmetric, and it removes the obvious cheat of
+challenging someone to "today only" at 4pm after a big morning.
+
+**Metrics in phase 1: vertical, top speed, distance.** All three come from
+columns that already exist.
+
+**Weekly settlement keeps a top-100 snapshot.** `user_stats.week_start` rolls
+over and the previous week's numbers are lost, so a snapshot is the only way
+past weeks survive. Storing every participant instead would grow at
+participants x 52 rows a year and need a retention policy.
+
+**Country is user-selected.** A new `country_code` on `profiles`, chosen in
+settings. Inferring it from GPS would reclassify a user who takes one trip
+abroad.
+
+**Win/loss record only.** No points, no tiers, no ladder in phase 1.
+
+## Out of scope
+
+Deliberately deferred. Each is a feature in its own right, not a field.
+
+- **LP and ranked tiers** (Black IV, Diamond, +25/-18 LP). The mockups show a
+  full ranked ladder. Shipping one needs a rating formula, protection against
+  alt-account feeding, a forfeit rule, and season resets. Phase 2, and only
+  after the W-L version shows people actually play.
+- **Most Runs as a metric.** Nothing in the repo counts runs. It needs GPS
+  segmentation that separates descents from lift rides.
+- **Resort scope** (per-resort boards, home resort, "any resort" filter).
+  `ski_resorts` was dropped in
+  [`007_drop_unused_ski_tables.sql`][migration-007];
+  resort geometry now lives only in the map-backend PostGIS `map_trail`
+  schema. A GPS-to-resort resolver is roughly a week on its own.
+- **Sharing a challenge outside the app.**
+
+## Data model
+
+Migration `019_duels_and_leaderboard.sql`.
+
+```sql
+-- Per-activity opt-in. Default false: nothing joins the board by accident.
+alter table activities
+  add column on_leaderboard boolean not null default false;
+
+create index activities_leaderboard_idx
+  on activities (start_time desc, user_id)
+  where on_leaderboard;
+
+-- ISO 3166-1 alpha-2. Null means the user has not chosen; global board only.
+alter table profiles add column country_code char(2);
+
+-- Weekly settlement snapshot: top 100 per metric per scope.
+create table leaderboard_weeks (
+  week_start date not null,
+  metric     text not null,   -- vertical | speed | distance
+  scope      text not null,   -- 'global' or an ISO-2 country code
+  rank       int  not null,
+  user_id    uuid not null references user_info(id),
+  value      double precision not null,
+  primary key (week_start, metric, scope, rank)
+);
+
+create table duels (
+  id                uuid primary key default gen_random_uuid(),
+  challenger_id     uuid not null references user_info(id),
+  opponent_id       uuid not null references user_info(id),
+  metric            text not null,
+  duration          text not null,   -- today | weekend | week
+  status            text not null,   -- pending|active|finished|declined|
+                                     -- cancelled|expired
+  starts_at         timestamptz,     -- written on accept, never before
+  ends_at           timestamptz,
+  challenger_value  double precision,
+  opponent_value    double precision,
+  winner_id         uuid,            -- null when drawn or unfinished
+  created_at        timestamptz not null default now(),
+  settled_at        timestamptz
+);
+
+-- One live duel per pair, in either direction.
+create unique index duels_one_live_per_pair
+  on duels (least(challenger_id, opponent_id),
+            greatest(challenger_id, opponent_id))
+  where status in ('pending', 'active');
+```
+
+There is no win/loss counter table. The record is counted from `duels`.
+
+```text
+ponytail: derive W-L from duels; add a counter table only if the profile
+query measurably slows.
+```
+
+## Scoring
+
+One module, `activity-backend/services/scoring.py`, with one metric mapping
+and two query shapes: a per-user total (duels) and a top-N grouping
+(leaderboard).
+
+```python
+METRIC_COLUMNS = {
+    "vertical": "elevation_gain_meters",
+    "distance": "distance_meters",
+}
+```
+
+`speed` is deliberately absent from that mapping. `activities.max_pace` is
+seconds per kilometre, so the fastest run is the *smallest* positive value,
+and the column defaults to `0` when there is no reading. Top speed is
+therefore `min(max_pace) where max_pace > 0`, not a max and not a sum. Every
+other metric is a plain sum.
+
+Window bounds are half-open, `start_time >= starts_at and start_time <
+ends_at`, so an activity cannot land in two consecutive weeks.
+
+Week boundaries are Monday 00:00 UTC, matching the existing `week_start`
+convention in `user_stats`.
+
+## API
+
+All routes live in `activity-backend`, which already owns `activities` and
+`user_stats`. The duel eligibility check reads `follows` — a read-only query
+against a table owned by community-backend, on the same database. That
+crossing is deliberate: the alternative puts duels in community-backend and
+makes every settlement an HTTP call per player.
+
+### Leaderboard
+
+```text
+GET /api/v1/leaderboard?metric=&scope=&limit=&cursor=
+GET /api/v1/leaderboard/me?metric=&scope=
+GET /api/v1/leaderboard/weeks/{week_start}?metric=&scope=
+```
+
+`metric` is `vertical | speed | distance`; `scope` is `global` or an ISO-2
+code. Every query takes a `LIMIT` and an explicit ordering; the default page
+is 50 and the cap is 100.
+
+`/leaderboard/me` exists because a user outside the top 100 still needs to
+see their own rank, and paging to find it is not acceptable.
+
+The opt-in toggle is not a new endpoint. `on_leaderboard` is a field on the
+existing activity update route.
+
+### Duels
+
+```text
+POST   /api/v1/duels                  {opponent_id, metric, duration}
+POST   /api/v1/duels/{id}/accept
+POST   /api/v1/duels/{id}/decline
+DELETE /api/v1/duels/{id}
+GET    /api/v1/duels?status=
+GET    /api/v1/duels/{id}
+GET    /api/v1/users/{id}/duel_record
+```
+
+`POST /duels` rejects with 403 unless both users follow each other, and with
+409 if a pending or active duel already exists between them. A pending duel
+expires 48 hours after creation.
+
+`DELETE` is the challenger withdrawing while the duel is still pending; it is
+not available once accepted.
+
+`duel_record` returns `{wins, losses, draws, recent}` where `recent` is the
+last five results as `W`/`L`/`D`.
+
+### Profile
+
+`country_code` is added to the existing profile update route in
+main-backend, which already owns `profiles`.
+
+## Settlement
+
+A second background worker in activity-backend, alongside the existing
+`PipelineWorker` started in
+[`main.py`](../../../backend/activity-backend/main.py). Same pattern, same
+lifespan, no scheduler dependency and no cron.
+
+`SettlementWorker.run_forever()` wakes every five minutes and does two
+things:
+
+1. **Duels.** For every duel with `status = 'active' and ends_at < now()`,
+   score both players, write `winner_id` (null on a draw), set
+   `status = 'finished'` and `settled_at`.
+2. **Weekly boards.** On the first wake after a week boundary, write the top
+   100 for each metric and each scope into `leaderboard_weeks`.
+3. **Stale invitations.** Any duel still `pending` 48 hours after
+   `created_at` becomes `expired`.
+
+`GET /duels/{id}` also settles lazily: if `ends_at` has passed and the duel
+is still active, it scores and writes before responding, so a user who opens
+the duel gets the result immediately rather than waiting for the worker.
+
+Both paths are safe to run concurrently across replicas. `leaderboard_weeks`
+writes are upserts on the primary key, and the duel update is conditional on
+`status = 'active'`, so only one writer wins.
+
+```text
+ponytail: idempotence comes from the primary key and a conditional update.
+No advisory lock until there is evidence one is needed.
+```
+
+## Structure
+
+The rules of this feature — which column a metric reads, whether a state
+transition is legal, who won — are pure functions with no database import.
+Everything that touches Supabase orchestrates those functions; it does not
+contain them. That split is what makes the feature testable without a
+database and safe to change later.
+
+### Backend
+
+```text
+activity-backend/
+  domain/competition/
+    metrics.py       # metric -> column, the max_pace rule, window bounds
+    duel.py          # Duel entity, legal transitions, winner resolution
+  services/
+    duel_operations.py         # persistence and orchestration
+    leaderboard_operations.py
+    settlement_worker.py
+  routes/
+    duel_routes.py
+    leaderboard_routes.py
+```
+
+`domain/competition/` imports nothing from `services/`. A test for "a draw
+produces no winner" or "top speed ignores a zero pace" constructs values and
+calls a function; it does not need a client, a fixture or a network.
+
+The `_operations.py` suffix matches the existing convention in
+community-backend (`follow_operations.py`,
+`community_post_read_operations.py`).
+
+### Frontend
+
+Two conventions exist in `frontend/lib/`: a `features/<domain>/{data,
+application}` layout, and a flat `services/` + `providers/` + `models/`
+layout. The follow mechanism — the closest analogue and the most recent work
+— uses the flat one, so this feature does too. Consistency with the
+neighbouring code beats consistency with a diagram.
+
+Domain purity still applies. `models/duel.dart` carries the rules:
+
+```dart
+bool get isDecidable;     // has the window closed
+bool canAcceptBy(String viewerId);
+Duration get remaining;
+```
+
+`services/` talks to the network, `providers/` holds state, `screens/`
+renders. A screen that computes a duel outcome is in the wrong layer.
+
+Presentation is assembled from the existing atoms in
+[`ui/st/`](../../../frontend/lib/ui/st) — `StCard`, `StStat`, `StTabBar`,
+`StPageHeader`, `StButtons`. A new atom goes in `ui/st/` only when two
+screens need it; one screen's widget stays private to that screen.
+
+## Frontend
+
+The leaderboard replaces the mock `Challenges` tab in
+[`community_screen.dart`][community-screen].
+
+```dart
+static const _labels = ['Threads', 'Leaderboards'];
+```
+
+`active_tab.dart`, `clubs_tab.dart` and `trails_tab.dart` stay on disk and
+stop being mounted. They are mock screens with no backend; removing them is a
+separate cleanup, not part of this change.
+
+New files:
+
+```text
+screens/leaderboard/  leaderboard_tab.dart
+                      duel_terms_screen.dart
+                      duel_detail_screen.dart
+                      incoming_duel_screen.dart
+services/             leaderboard_service.dart, duel_service.dart
+services/apis/        leaderboard_api.dart, duel_api.dart
+providers/            duel_provider.dart
+models/               leaderboard_entry.dart, duel.dart, duel_record.dart
+```
+
+The `Challenge` button appears only on the **Friends** board, never on
+Global, because a duel requires a mutual follow.
+
+Incoming duel invitations are surfaced through the existing
+[`NotificationProvider`][notification-provider],
+which already derives its list from pending follow requests. Pending duels
+become a second source in the same provider — no new polling and no new
+infrastructure.
+
+Colours come from `context.colors`. The guard test at
+`frontend/test/core/design_system_guard_test.dart` fails the build on a raw
+hex, so the mockups' palette is mapped to existing roles rather than copied
+as literals.
+
+## Privacy
+
+The board shows aggregates only — display name, total, rank. It never links
+to an activity and never exposes an activity's contents, so an activity with
+`private` visibility can still count towards a total without leaking. Tapping
+a name opens the profile, where the existing `can_read_account` gate applies
+unchanged.
+
+Eligibility is resolved server-side in the query, never filtered in the
+client. A duel between users who stop following each other mid-window still
+finishes: eligibility is checked when the challenge is accepted, not
+continuously.
+
+## Testing
+
+Backend, in `activity-backend/tests/`:
+
+- Scoring boundaries: `max_pace = 0` excluded from top speed, half-open
+  window edges, a draw, a user with no activities in the window.
+- The mutual-follow gate rejects a one-directional follow and a stranger.
+- Settlement is idempotent: running it twice leaves one result.
+- The leaderboard excludes activities with `on_leaderboard = false`.
+
+Frontend, in `frontend/test/`:
+
+- Duel status to button state, in the shape of
+  `test/widgets/follow_button_request_test.dart`.
+- `NotificationProvider` surfaces a pending duel with the id needed to open
+  it.
+
+A contract test covers the duel and leaderboard response shapes through
+`shared/contract_tests.py`.
+
+## Estimate
+
+Backend, roughly two to three days: the migration, the scoring module, eight
+routes and the settlement worker. Frontend, roughly three to four days: four
+screens, two services, one provider. About a week in total.
+
+[migration-007]: ../../../backend/db/migrations/007_drop_unused_ski_tables.sql
+[community-screen]: ../../../frontend/lib/screens/community/community_screen.dart
+[notification-provider]: ../../../frontend/lib/providers/notification_provider.dart

--- a/docs/superpowers/specs/2026-09-02-duel-and-leaderboard-design.md
+++ b/docs/superpowers/specs/2026-09-02-duel-and-leaderboard-design.md
@@ -60,6 +60,11 @@ participants x 52 rows a year and need a retention policy.
 settings. Inferring it from GPS would reclassify a user who takes one trip
 abroad.
 
+**Three scopes, one predicate.** `global`, `friends` and a country code are
+decided by a single SQL function, `leaderboard_in_scope`, called by the
+board, the placing and the snapshot. Repeating the predicate in three places
+is how those three would stop agreeing about who is on a board.
+
 **Win/loss record only.** No points, no tiers, no ladder in phase 1.
 
 ## Out of scope
@@ -178,9 +183,17 @@ GET /api/v1/leaderboard/me?metric=&scope=
 GET /api/v1/leaderboard/weeks/{week_start}?metric=&scope=
 ```
 
-`metric` is `vertical | speed | distance`; `scope` is `global` or an ISO-2
-code. Every query takes a `LIMIT` and an explicit ordering; the default page
-is 50 and the cap is 100.
+`metric` is `vertical | speed | distance`; `scope` is `global`, `friends`, or
+an ISO-2 code.
+
+`friends` ranks the caller against the people they mutually follow. It is a
+different board for every viewer, which is why it is never snapshotted --
+there is no single week to write down -- and why the Challenge button lives
+only there: a duel needs a mutual follow to be offered at all, so the friends
+board is exactly the set of people who can be challenged.
+
+Every query takes a `LIMIT` and an explicit ordering; the default page is 50
+and the cap is 100.
 
 `/leaderboard/me` exists because a user outside the top 100 still needs to
 see their own rank, and paging to find it is not acceptable.
@@ -321,12 +334,17 @@ New files:
 screens/leaderboard/  leaderboard_tab.dart
                       duel_terms_screen.dart
                       duel_detail_screen.dart
-                      incoming_duel_screen.dart
+                      duel_formatting.dart
 services/             leaderboard_service.dart, duel_service.dart
 services/apis/        leaderboard_api.dart, duel_api.dart
 providers/            duel_provider.dart
-models/               leaderboard_entry.dart, duel.dart, duel_record.dart
+models/               leaderboard_entry.dart, duel.dart
 ```
+
+There is no separate screen for an incoming challenge. `duel_detail_screen`
+renders every state, so a notification tap has one destination: a challenge
+answered on another device opens to the result rather than to a dead Accept
+button.
 
 The `Challenge` button appears only on the **Friends** board, never on
 Global, because a duel requires a mutual follow.

--- a/docs/superpowers/specs/2026-09-02-duel-and-leaderboard-design.md
+++ b/docs/superpowers/specs/2026-09-02-duel-and-leaderboard-design.md
@@ -66,7 +66,8 @@ board and the duel cards read. `profiles` is empty and stays empty:
 `user_info`, so main-backend's `create_profile` fails with 23503 every time
 and no row is ever made. main-backend already renders profiles from
 `user_info` at read time for the same reason. Migration 019 got this wrong;
-021 corrects it.
+021 corrects it. The underlying breakage is issue #43; the missing country
+picker is issue #44.
 
 **Three scopes, one predicate.** `global`, `friends` and a country code are
 decided by a single SQL function, `leaderboard_in_scope`, called by the

--- a/frontend/lib/core/di/service_locator.dart
+++ b/frontend/lib/core/di/service_locator.dart
@@ -17,14 +17,18 @@ import 'package:snowtrak/providers/auth_provider.dart';
 import 'package:snowtrak/services/activities_service.dart';
 import 'package:snowtrak/services/auth_service.dart';
 import 'package:snowtrak/services/community_service.dart';
+import 'package:snowtrak/services/duel_service.dart';
 import 'package:snowtrak/services/follow_service.dart';
+import 'package:snowtrak/services/leaderboard_service.dart';
 import 'package:snowtrak/services/profile_service.dart';
 import 'package:snowtrak/features/track_pipeline/application/activity_upload_coordinator.dart';
 import 'package:snowtrak/services/apis/activities_api.dart';
 import 'package:snowtrak/services/apis/activity_upload_api.dart';
 import 'package:snowtrak/services/apis/auth_api.dart';
 import 'package:snowtrak/services/apis/community_api.dart';
+import 'package:snowtrak/services/apis/duel_api.dart';
 import 'package:snowtrak/services/apis/follow_api.dart';
+import 'package:snowtrak/services/apis/leaderboard_api.dart';
 import 'package:snowtrak/services/apis/map_activities_api.dart';
 import 'package:snowtrak/services/apis/privacy_api.dart';
 import 'package:snowtrak/services/apis/users_api.dart';
@@ -99,6 +103,15 @@ Future<void> setupServiceLocatorWithEnvironment({
   sl.registerLazySingleton<FollowApi>(
     () => FollowApi(dio: sl<Dio>(instanceName: 'community')),
   );
+  // activity-backend, not community: the board and a duel both aggregate
+  // `activities`, so they live with the activities. See
+  // docs/service-ownership.md.
+  sl.registerLazySingleton<LeaderboardApi>(
+    () => LeaderboardApi(dio: sl<Dio>(instanceName: 'activity')),
+  );
+  sl.registerLazySingleton<DuelApi>(
+    () => DuelApi(dio: sl<Dio>(instanceName: 'activity')),
+  );
   // main-backend, not community: `/users/me/privacy` lives next to
   // `/users/me/profile` (see users_profile_routes.py), not next to follows.
   sl.registerLazySingleton<PrivacyApi>(
@@ -146,6 +159,12 @@ Future<void> setupServiceLocatorWithEnvironment({
   );
   sl.registerLazySingleton<FollowService>(
     () => FollowService(followApi: sl<FollowApi>()),
+  );
+  sl.registerLazySingleton<LeaderboardService>(
+    () => LeaderboardService(leaderboardApi: sl<LeaderboardApi>()),
+  );
+  sl.registerLazySingleton<DuelService>(
+    () => DuelService(duelApi: sl<DuelApi>()),
   );
 
   sl.registerLazySingleton<WeatherService>(() => WeatherService());

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:snowtrak/features/activities/data/activities_context_repository.
 import 'package:snowtrak/features/auth/data/auth_session_store.dart';
 import 'package:snowtrak/providers/auth_provider.dart';
 import 'package:snowtrak/providers/activity_provider.dart';
+import 'package:snowtrak/providers/duel_provider.dart';
 import 'package:snowtrak/providers/notification_provider.dart';
 import 'package:snowtrak/screens/auth/login_screen.dart';
 import 'package:snowtrak/screens/home/home_screen.dart';
@@ -82,8 +83,15 @@ class _SnowtrakAppState extends State<SnowtrakApp> {
           create: (_) => sl<ActivitiesContextRepository>(),
         ),
         ChangeNotifierProvider(
-          create: (_) => NotificationProvider(followService: sl())
-            ..loadNotifications(),
+          // No viewer id yet: auth has not resolved at this point, so the
+          // eager load reads follow requests only. The notifications screen
+          // reloads with the viewer and picks up duels then.
+          create: (_) =>
+              NotificationProvider(followService: sl(), duelService: sl())
+                ..loadNotifications(),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => DuelProvider(duelService: sl()),
         ),
       ],
       child: MaterialApp(

--- a/frontend/lib/models/duel.dart
+++ b/frontend/lib/models/duel.dart
@@ -1,0 +1,210 @@
+/// What a duel or a board measures.
+///
+/// The wire values match `domain/competition/metrics.py`; a rename is a
+/// two-sided break.
+enum DuelMetric {
+  vertical('vertical', 'Most Vertical', 'Highest total descent wins'),
+  speed('speed', 'Top Speed', 'Single fastest recorded speed wins'),
+  distance('distance', 'Total Distance', 'Greatest total ski distance wins');
+
+  const DuelMetric(this.value, this.label, this.blurb);
+
+  final String value;
+  final String label;
+  final String blurb;
+
+  static DuelMetric fromValue(String? value) => DuelMetric.values.firstWhere(
+        (metric) => metric.value == value,
+        orElse: () => DuelMetric.vertical,
+      );
+}
+
+/// How long a duel runs once accepted.
+enum DuelDuration {
+  today('today', 'Today only', 'Ends at midnight'),
+  weekend('weekend', 'This weekend', 'Friday to Sunday'),
+  week('week', 'This week', '7 days from acceptance');
+
+  const DuelDuration(this.value, this.label, this.blurb);
+
+  final String value;
+  final String label;
+  final String blurb;
+
+  static DuelDuration fromValue(String? value) =>
+      DuelDuration.values.firstWhere(
+        (duration) => duration.value == value,
+        orElse: () => DuelDuration.week,
+      );
+}
+
+enum DuelStatus {
+  pending,
+  active,
+  finished,
+  declined,
+  cancelled,
+  expired;
+
+  static DuelStatus fromValue(String? value) => DuelStatus.values.firstWhere(
+        (status) => status.name == value,
+        orElse: () => DuelStatus.pending,
+      );
+}
+
+/// One head-to-head.
+///
+/// Carries the rules that read off its own fields — whether the window has
+/// closed, who won from this viewer's side, how long is left. The server
+/// decides all of them again; these exist so a screen never has to.
+class Duel {
+  const Duel({
+    required this.id,
+    required this.challengerId,
+    required this.opponentId,
+    required this.metric,
+    required this.duration,
+    required this.status,
+    required this.createdAt,
+    this.startsAt,
+    this.endsAt,
+    this.challengerValue,
+    this.opponentValue,
+    this.winnerId,
+    this.settledAt,
+    this.challengerName,
+    this.challengerAvatarUrl,
+    this.opponentName,
+    this.opponentAvatarUrl,
+  });
+
+  factory Duel.fromJson(Map<String, dynamic> json) {
+    return Duel(
+      id: json['id'] as String? ?? '',
+      challengerId: json['challenger_id'] as String? ?? '',
+      opponentId: json['opponent_id'] as String? ?? '',
+      metric: DuelMetric.fromValue(json['metric'] as String?),
+      duration: DuelDuration.fromValue(json['duration'] as String?),
+      status: DuelStatus.fromValue(json['status'] as String?),
+      createdAt: DateTime.tryParse(json['created_at'] as String? ?? '') ??
+          DateTime.now(),
+      startsAt: DateTime.tryParse(json['starts_at'] as String? ?? ''),
+      endsAt: DateTime.tryParse(json['ends_at'] as String? ?? ''),
+      challengerValue: (json['challenger_value'] as num?)?.toDouble(),
+      opponentValue: (json['opponent_value'] as num?)?.toDouble(),
+      winnerId: json['winner_id'] as String?,
+      settledAt: DateTime.tryParse(json['settled_at'] as String? ?? ''),
+      challengerName: json['challenger_name'] as String?,
+      challengerAvatarUrl: json['challenger_avatar_url'] as String?,
+      opponentName: json['opponent_name'] as String?,
+      opponentAvatarUrl: json['opponent_avatar_url'] as String?,
+    );
+  }
+
+  final String id;
+  final String challengerId;
+  final String opponentId;
+  final DuelMetric metric;
+  final DuelDuration duration;
+  final DuelStatus status;
+  final DateTime createdAt;
+  final DateTime? startsAt;
+  final DateTime? endsAt;
+  final double? challengerValue;
+  final double? opponentValue;
+  final String? winnerId;
+  final DateTime? settledAt;
+
+  /// Filled by the list and detail endpoints from one profiles read per
+  /// page. Null on a payload that predates them.
+  final String? challengerName;
+  final String? challengerAvatarUrl;
+  final String? opponentName;
+  final String? opponentAvatarUrl;
+
+  bool get isLive =>
+      status == DuelStatus.pending || status == DuelStatus.active;
+
+  /// A finished duel where neither player came out ahead.
+  bool get isDraw => status == DuelStatus.finished && winnerId == null;
+
+  String otherPlayer(String viewerId) =>
+      viewerId == challengerId ? opponentId : challengerId;
+
+  String otherPlayerName(String viewerId) {
+    final name =
+        viewerId == challengerId ? opponentName : challengerName;
+    return (name == null || name.isEmpty) ? 'Skier' : name;
+  }
+
+  String? otherPlayerAvatarUrl(String viewerId) =>
+      viewerId == challengerId ? opponentAvatarUrl : challengerAvatarUrl;
+
+  double? valueFor(String userId) =>
+      userId == challengerId ? challengerValue : opponentValue;
+
+  /// Whether [viewerId] is the one being asked, and the ask still stands.
+  bool awaitingAnswerFrom(String viewerId) =>
+      status == DuelStatus.pending && viewerId == opponentId;
+
+  /// Whether [viewerId] sent this and is waiting.
+  bool awaitingAnswerFor(String viewerId) =>
+      status == DuelStatus.pending && viewerId == challengerId;
+
+  /// Time left in the window, or `null` when there is no window running.
+  ///
+  /// Clamped at zero: a duel whose window closed a minute ago is over, not
+  /// running backwards, and the screen shows a result rather than a
+  /// negative countdown.
+  Duration? remainingAt(DateTime now) {
+    final end = endsAt;
+    if (status != DuelStatus.active || end == null) return null;
+    final left = end.difference(now);
+    return left.isNegative ? Duration.zero : left;
+  }
+
+  /// Time left to answer, on the same terms as `remainingAt`.
+  Duration? answerWindowAt(DateTime now) {
+    if (status != DuelStatus.pending) return null;
+    final left = createdAt.add(inviteTtl).difference(now);
+    return left.isNegative ? Duration.zero : left;
+  }
+}
+
+/// Mirrors `INVITE_TTL` in the backend's duel domain. A challenge shown as
+/// answerable that the server has already expired is a worse lie than a
+/// duplicated constant.
+const Duration inviteTtl = Duration(hours: 48);
+
+/// A player's head-to-head history.
+class DuelRecord {
+  const DuelRecord({
+    this.wins = 0,
+    this.losses = 0,
+    this.draws = 0,
+    this.recent = const <String>[],
+  });
+
+  factory DuelRecord.fromJson(Map<String, dynamic> json) {
+    final recent = json['recent'];
+    return DuelRecord(
+      wins: (json['wins'] as num?)?.toInt() ?? 0,
+      losses: (json['losses'] as num?)?.toInt() ?? 0,
+      draws: (json['draws'] as num?)?.toInt() ?? 0,
+      recent: recent is List ? recent.map((e) => e.toString()).toList() : const [],
+    );
+  }
+
+  final int wins;
+  final int losses;
+  final int draws;
+
+  /// Most recent first, each `W`, `L` or `D`.
+  final List<String> recent;
+
+  int get played => wins + losses + draws;
+
+  /// Null rather than zero when nothing has been played — "0%" and "no
+  /// duels yet" are different things to show.
+  double? get winRate => played == 0 ? null : wins / played;
+}

--- a/frontend/lib/models/leaderboard_entry.dart
+++ b/frontend/lib/models/leaderboard_entry.dart
@@ -1,0 +1,92 @@
+import 'package:snowtrak/models/duel.dart';
+
+/// One row of a board.
+///
+/// Deliberately has no activity id. The board shows a name, a total and a
+/// rank; linking to an activity is what would leak a private one.
+class LeaderboardEntry {
+  const LeaderboardEntry({
+    required this.rank,
+    required this.userId,
+    required this.value,
+    required this.displayName,
+    this.username,
+    this.avatarUrl,
+    this.countryCode,
+  });
+
+  factory LeaderboardEntry.fromJson(Map<String, dynamic> json) {
+    return LeaderboardEntry(
+      rank: (json['rank'] as num?)?.toInt() ?? 0,
+      userId: json['user_id'] as String? ?? '',
+      value: (json['value'] as num?)?.toDouble() ?? 0,
+      displayName: json['display_name'] as String? ?? 'Skier',
+      username: json['username'] as String?,
+      avatarUrl: json['avatar_url'] as String?,
+      countryCode: json['country_code'] as String?,
+    );
+  }
+
+  final int rank;
+  final String userId;
+  final double value;
+  final String displayName;
+  final String? username;
+  final String? avatarUrl;
+  final String? countryCode;
+}
+
+/// A board page and the terms it was read under.
+class Leaderboard {
+  const Leaderboard({
+    required this.metric,
+    required this.scope,
+    required this.weekStart,
+    required this.settled,
+    required this.entries,
+  });
+
+  factory Leaderboard.fromJson(Map<String, dynamic> json) {
+    final entries = json['entries'];
+    return Leaderboard(
+      metric: DuelMetric.fromValue(json['metric'] as String?),
+      scope: json['scope'] as String? ?? globalScope,
+      weekStart: json['week_start'] as String? ?? '',
+      settled: json['settled'] as bool? ?? false,
+      entries: entries is List
+          ? entries
+              .whereType<Map<String, dynamic>>()
+              .map(LeaderboardEntry.fromJson)
+              .toList()
+          : const <LeaderboardEntry>[],
+    );
+  }
+
+  final DuelMetric metric;
+
+  /// `globalScope` or an ISO 3166-1 alpha-2 country code.
+  final String scope;
+  final String weekStart;
+
+  /// False for the week being skied, true for a settled snapshot.
+  final bool settled;
+  final List<LeaderboardEntry> entries;
+}
+
+/// Where the viewer stands, however deep in the board.
+class LeaderboardPlacing {
+  const LeaderboardPlacing({this.rank, this.value = 0});
+
+  factory LeaderboardPlacing.fromJson(Map<String, dynamic> json) {
+    return LeaderboardPlacing(
+      rank: (json['rank'] as num?)?.toInt(),
+      value: (json['value'] as num?)?.toDouble() ?? 0,
+    );
+  }
+
+  /// Null when the viewer has not placed this week.
+  final int? rank;
+  final double value;
+}
+
+const String globalScope = 'global';

--- a/frontend/lib/providers/duel_provider.dart
+++ b/frontend/lib/providers/duel_provider.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/foundation.dart';
+import 'package:snowtrak/core/errors/app_result.dart';
+import 'package:snowtrak/models/duel.dart';
+import 'package:snowtrak/services/duel_service.dart';
+
+/// Duel state for the leaderboard tab and the duel screens.
+///
+/// Holds one page of the viewer's duels and splits it into the three things
+/// a screen actually asks for: what needs an answer, what is running, what
+/// is over. The split is here rather than in each screen because "needs an
+/// answer" depends on who is looking, and a widget that recomputes that is a
+/// widget that will get it wrong once.
+class DuelProvider extends ChangeNotifier {
+  DuelProvider({required DuelService duelService})
+      : _duelService = duelService;
+
+  final DuelService _duelService;
+
+  List<Duel> _duels = const [];
+  bool _isLoading = false;
+  String? _error;
+  String _viewerId = '';
+
+  List<Duel> get duels => _duels;
+  bool get isLoading => _isLoading;
+  String? get error => _error;
+
+  /// Challenges waiting on the viewer to accept or decline.
+  List<Duel> get incoming =>
+      _duels.where((duel) => duel.awaitingAnswerFrom(_viewerId)).toList();
+
+  /// Challenges the viewer sent that nobody has answered.
+  List<Duel> get outgoing =>
+      _duels.where((duel) => duel.awaitingAnswerFor(_viewerId)).toList();
+
+  List<Duel> get active =>
+      _duels.where((duel) => duel.status == DuelStatus.active).toList();
+
+  bool get hasIncoming => incoming.isNotEmpty;
+
+  /// Loads the viewer's duels.
+  ///
+  /// ponytail: one page of 20, no pagination. A duel list is a screen, and
+  /// nobody has 20 live duels; add paging when the finished ones need
+  /// scrolling back through.
+  Future<void> load(String viewerId) async {
+    _viewerId = viewerId;
+    _isLoading = true;
+    _error = null;
+    notifyListeners();
+
+    final result = await _duelService.list(limit: 20);
+    switch (result) {
+      case AppSuccess(:final value):
+        _duels = value;
+        _error = null;
+      case AppFailure(:final error):
+        _error = error.userMessage;
+    }
+
+    _isLoading = false;
+    notifyListeners();
+  }
+
+  Future<AppResult<Duel>> challenge({
+    required String opponentId,
+    required DuelMetric metric,
+    required DuelDuration duration,
+  }) async {
+    final result = await _duelService.challenge(
+      opponentId: opponentId,
+      metric: metric,
+      duration: duration,
+    );
+    if (result case AppSuccess(:final value)) {
+      _replaceOrInsert(value);
+    }
+    return result;
+  }
+
+  Future<AppResult<Duel>> accept(String duelId) => _answer(
+        () => _duelService.accept(duelId),
+      );
+
+  Future<AppResult<Duel>> decline(String duelId) => _answer(
+        () => _duelService.decline(duelId),
+      );
+
+  Future<AppResult<Duel>> cancel(String duelId) => _answer(
+        () => _duelService.cancel(duelId),
+      );
+
+  /// Re-reads one duel.
+  ///
+  /// The server settles a closed window on read, so opening a finished duel
+  /// is also what produces its result.
+  Future<AppResult<Duel>> refreshOne(String duelId) => _answer(
+        () => _duelService.get(duelId),
+      );
+
+  Future<AppResult<Duel>> _answer(Future<AppResult<Duel>> Function() call) async {
+    final result = await call();
+    if (result case AppSuccess(:final value)) {
+      _replaceOrInsert(value);
+    }
+    return result;
+  }
+
+  void _replaceOrInsert(Duel duel) {
+    final index = _duels.indexWhere((existing) => existing.id == duel.id);
+    final next = List<Duel>.of(_duels);
+    if (index == -1) {
+      next.insert(0, duel);
+    } else {
+      next[index] = duel;
+    }
+    _duels = next;
+    notifyListeners();
+  }
+}

--- a/frontend/lib/providers/notification_provider.dart
+++ b/frontend/lib/providers/notification_provider.dart
@@ -1,23 +1,31 @@
 import 'package:flutter/foundation.dart';
 import 'package:snowtrak/core/errors/app_result.dart';
+import 'package:snowtrak/models/duel.dart';
 import 'package:snowtrak/models/notification.dart';
+import 'package:snowtrak/services/duel_service.dart';
 import 'package:snowtrak/services/follow_service.dart';
 
 /// Notification state.
 ///
-/// Every notification here is *derived* from a pending follow request, not
-/// stored: `/api/v1/follows/me/requests` is the only real notification-shaped
-/// event the backend has today. `/api/v1/notifications/*` is a single global
-/// in-memory queue with no user id and no auth, so reading it would have shown
-/// every user each other's notifications -- this provider no longer touches it.
+/// Every notification here is *derived*, not stored: from a pending follow
+/// request, and from a duel challenge waiting on the viewer's answer. Those
+/// are the two notification-shaped events the backend actually has.
+/// `/api/v1/notifications/*` was a single global in-memory queue with no user
+/// id and no auth, so reading it would have shown every user each other's
+/// notifications -- this provider does not touch it.
 ///
-/// ponytail: derive instead of persist. When a second real event exists
-/// (kudos, comments), give notifications their own table and read that.
+/// ponytail: derive instead of persist. At a third source, or the first one
+/// that is not a list the user can already see somewhere else, give
+/// notifications their own table and read that.
 class NotificationProvider extends ChangeNotifier {
-  NotificationProvider({required FollowService followService})
-      : _followService = followService;
+  NotificationProvider({
+    required FollowService followService,
+    required DuelService duelService,
+  })  : _followService = followService,
+        _duelService = duelService;
 
   final FollowService _followService;
+  final DuelService _duelService;
 
   List<AppNotification> _notifications = [];
   bool _isLoading = false;
@@ -65,25 +73,45 @@ class NotificationProvider extends ChangeNotifier {
     return grouped;
   }
 
-  /// Rebuild the list from the pending follow requests.
+  /// Rebuilds the list from pending follow requests and pending duels.
   ///
-  /// ponytail: one page, so it stops at 20 -- the same ceiling the profile
-  /// header's badge already accepts.
-  Future<void> loadNotifications() async {
+  /// [viewerId] decides which duels count: a pending duel the viewer *sent*
+  /// is not a notification, it is something they are waiting on. Without it
+  /// only follow requests are read, which is the case at app start before
+  /// auth has resolved.
+  ///
+  /// ponytail: one page of each, so it stops at 20 apiece -- the same
+  /// ceiling the profile header's badge already accepts.
+  Future<void> loadNotifications({String? viewerId}) async {
     _isLoading = true;
     _error = null;
     notifyListeners();
 
-    final result = await _followService.getRequests(limit: 20);
+    final requests = await _followService.getRequests(limit: 20);
+    final duels = (viewerId == null || viewerId.isEmpty)
+        ? null
+        : await _duelService.list(status: DuelStatus.pending, limit: 20);
 
-    switch (result) {
+    final combined = <AppNotification>[];
+    switch (requests) {
       case AppSuccess(:final value):
-        _notifications = value.map(_followRequestNotification).toList();
+        combined.addAll(value.map(_followRequestNotification));
         _error = null;
       case AppFailure(:final error):
         _error = error.userMessage;
     }
+    if (duels case AppSuccess(:final value)) {
+      combined.addAll(
+        value
+            .where((duel) => duel.awaitingAnswerFrom(viewerId!))
+            .map(_duelNotification),
+      );
+    }
+    // Newest first across both sources; each source is already ordered, but
+    // interleaving them is the whole point of merging.
+    combined.sort((a, b) => b.createdAt.compareTo(a.createdAt));
 
+    _notifications = combined;
     _isLoading = false;
     notifyListeners();
   }
@@ -142,6 +170,25 @@ class NotificationProvider extends ChangeNotifier {
       createdAt: createdAt ?? DateTime.now(),
       senderName: name,
       metadata: {'user_id': userId},
+    );
+  }
+
+  /// One pending duel, as a notification.
+  ///
+  /// `metadata['duel_id']` is what the tap handler opens. The duel screen
+  /// handles every state, so a challenge that was answered from another
+  /// device still opens to something truthful rather than to a dead accept
+  /// button.
+  static AppNotification _duelNotification(Duel duel) {
+    final name = duel.challengerName ?? 'Someone';
+    return AppNotification(
+      id: 'duel:${duel.id}',
+      type: NotificationType.challenge,
+      title: 'Battle challenge',
+      message: '$name challenged you to ${duel.metric.label}',
+      createdAt: duel.createdAt,
+      senderName: name,
+      metadata: {'duel_id': duel.id},
     );
   }
 

--- a/frontend/lib/screens/community/community_screen.dart
+++ b/frontend/lib/screens/community/community_screen.dart
@@ -1,10 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:snowtrak/core/theme.dart';
 import 'package:snowtrak/screens/community/threads_tab.dart';
-import 'package:snowtrak/screens/groups/active_tab.dart';
-import 'package:snowtrak/screens/groups/challenges_tab.dart';
-import 'package:snowtrak/screens/groups/clubs_tab.dart';
-import 'package:snowtrak/screens/groups/trails_tab.dart';
+import 'package:snowtrak/screens/leaderboard/leaderboard_tab.dart';
 import 'package:snowtrak/ui/st/st.dart';
 
 /// Community is the social half of the product: the feed plus everything that
@@ -19,7 +16,10 @@ class CommunityScreen extends StatefulWidget {
 
 class _CommunityScreenState extends State<CommunityScreen>
     with SingleTickerProviderStateMixin {
-  static const _labels = ['Threads', 'Activity', 'Challenges', 'Clubs', 'Trails'];
+  // Activity, Clubs and Trails are mock screens with no backend behind them.
+  // They stay on disk under screens/groups/ and stop being mounted; deleting
+  // them is a cleanup, not part of shipping the board.
+  static const _labels = ['Threads', 'Leaderboards'];
 
   late final TabController _tabController =
       TabController(length: _labels.length, vsync: this);
@@ -59,10 +59,7 @@ class _CommunityScreenState extends State<CommunityScreen>
                 controller: _tabController,
                 children: const [
                   ThreadsTab(),
-                  ActiveTab(),
-                  ChallengesTab(),
-                  ClubsTab(),
-                  TrailsTab(),
+                  LeaderboardTab(),
                 ],
               ),
             ),

--- a/frontend/lib/screens/leaderboard/duel_detail_screen.dart
+++ b/frontend/lib/screens/leaderboard/duel_detail_screen.dart
@@ -1,0 +1,355 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:snowtrak/core/errors/app_result.dart';
+import 'package:snowtrak/core/theme.dart';
+import 'package:snowtrak/models/duel.dart';
+import 'package:snowtrak/providers/auth_provider.dart';
+import 'package:snowtrak/providers/duel_provider.dart';
+import 'package:snowtrak/screens/leaderboard/duel_formatting.dart';
+import 'package:snowtrak/screens/profile/user_profile_screen.dart';
+import 'package:snowtrak/ui/st/st.dart';
+
+/// Opens one duel. Works for every state, including a challenge waiting on
+/// the viewer, so a notification tap has one destination rather than three.
+Future<void> openDuel(BuildContext context, String duelId) async {
+  if (duelId.trim().isEmpty) return;
+  await Navigator.of(context).push<void>(
+    MaterialPageRoute<void>(builder: (_) => DuelDetailScreen(duelId: duelId)),
+  );
+}
+
+class DuelDetailScreen extends StatefulWidget {
+  const DuelDetailScreen({super.key, required this.duelId});
+
+  final String duelId;
+
+  @override
+  State<DuelDetailScreen> createState() => _DuelDetailScreenState();
+}
+
+class _DuelDetailScreenState extends State<DuelDetailScreen> {
+  Duel? _duel;
+  bool _busy = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  /// Reading a duel is also what settles it: the server scores a window that
+  /// has closed before it answers, so opening a finished duel produces the
+  /// result rather than waiting on the background sweep.
+  Future<void> _load() async {
+    final result = await context.read<DuelProvider>().refreshOne(widget.duelId);
+    if (!mounted) return;
+    setState(() {
+      switch (result) {
+        case AppSuccess(:final value):
+          _duel = value;
+          _error = null;
+        case AppFailure(:final error):
+          _error = error.userMessage;
+      }
+      _busy = false;
+    });
+  }
+
+  Future<void> _answer(Future<AppResult<Duel>> Function() call) async {
+    setState(() => _busy = true);
+    final result = await call();
+    if (!mounted) return;
+    setState(() {
+      _busy = false;
+      if (result case AppSuccess(:final value)) _duel = value;
+    });
+    if (result case AppFailure(:final error)) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(error.userMessage)),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final viewerId = context.watch<AuthProvider>().user?.id ?? '';
+    final duel = _duel;
+
+    return Scaffold(
+      backgroundColor: context.colors.background,
+      appBar: AppBar(
+        backgroundColor: context.colors.surface,
+        title: const Text('Battle'),
+      ),
+      body: SafeArea(
+        child: duel == null
+            ? Center(
+                child: _busy
+                    ? const CircularProgressIndicator()
+                    : Text(
+                        _error ?? 'Battle not found',
+                        style: SnowtrakTypography.bodyMedium.copyWith(
+                          color: context.colors.textSecondary,
+                        ),
+                      ),
+              )
+            : _body(duel, viewerId),
+      ),
+    );
+  }
+
+  Widget _body(Duel duel, String viewerId) {
+    return ListView(
+      padding: const EdgeInsets.all(SnowtrakSpacing.md),
+      children: [
+        _Versus(duel: duel, viewerId: viewerId),
+        const SizedBox(height: SnowtrakSpacing.md),
+        _Terms(duel: duel),
+        const SizedBox(height: SnowtrakSpacing.md),
+        _Status(duel: duel, viewerId: viewerId),
+        const SizedBox(height: SnowtrakSpacing.lg),
+        ..._actions(duel, viewerId),
+      ],
+    );
+  }
+
+  List<Widget> _actions(Duel duel, String viewerId) {
+    if (duel.awaitingAnswerFrom(viewerId)) {
+      final provider = context.read<DuelProvider>();
+      return [
+        SizedBox(
+          height: 48,
+          child: FilledButton(
+            onPressed:
+                _busy ? null : () => _answer(() => provider.accept(duel.id)),
+            style: FilledButton.styleFrom(
+              backgroundColor: context.colors.primary,
+              foregroundColor: context.colors.textOnPrimary,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(SnowtrakRadius.md),
+              ),
+            ),
+            child: const Text('Accept challenge'),
+          ),
+        ),
+        const SizedBox(height: SnowtrakSpacing.sm),
+        SizedBox(
+          height: 48,
+          child: OutlinedButton(
+            onPressed:
+                _busy ? null : () => _answer(() => provider.decline(duel.id)),
+            style: OutlinedButton.styleFrom(
+              foregroundColor: context.colors.textPrimary,
+              side: BorderSide(color: context.colors.borderStrong),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(SnowtrakRadius.md),
+              ),
+            ),
+            child: const Text('Decline'),
+          ),
+        ),
+      ];
+    }
+
+    if (duel.awaitingAnswerFor(viewerId)) {
+      final provider = context.read<DuelProvider>();
+      return [
+        Center(
+          child: TextButton(
+            onPressed:
+                _busy ? null : () => _answer(() => provider.cancel(duel.id)),
+            child: const Text('Cancel challenge'),
+          ),
+        ),
+      ];
+    }
+
+    return const [];
+  }
+}
+
+class _Versus extends StatelessWidget {
+  const _Versus({required this.duel, required this.viewerId});
+
+  final Duel duel;
+  final String viewerId;
+
+  @override
+  Widget build(BuildContext context) {
+    final mine = duel.valueFor(viewerId);
+    final theirs = duel.valueFor(duel.otherPlayer(viewerId));
+    return StCard(
+      padding: const EdgeInsets.all(SnowtrakSpacing.md),
+      child: Row(
+        children: [
+          Expanded(
+            child: _Side(
+              name: 'You',
+              value: mine,
+              metric: duel.metric,
+              leading: duel.winnerId == viewerId,
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: SnowtrakSpacing.sm),
+            child: Text(
+              'vs',
+              style: SnowtrakTypography.labelMedium.copyWith(
+                color: context.colors.textTertiary,
+              ),
+            ),
+          ),
+          Expanded(
+            child: GestureDetector(
+              onTap: () => openUserProfile(
+                context,
+                duel.otherPlayer(viewerId),
+                displayName: duel.otherPlayerName(viewerId),
+              ),
+              child: _Side(
+                name: duel.otherPlayerName(viewerId),
+                value: theirs,
+                metric: duel.metric,
+                leading: duel.winnerId == duel.otherPlayer(viewerId),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Side extends StatelessWidget {
+  const _Side({
+    required this.name,
+    required this.value,
+    required this.metric,
+    required this.leading,
+  });
+
+  final String name;
+  final double? value;
+  final DuelMetric metric;
+  final bool leading;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text(
+          name,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: SnowtrakTypography.labelLarge.copyWith(
+            color: context.colors.textPrimary,
+          ),
+        ),
+        const SizedBox(height: SnowtrakSpacing.xs),
+        Text(
+          // A running duel has no scores yet. An em dash says "not counted
+          // yet"; a zero would say "skied nothing", which is a different
+          // and usually wrong claim.
+          value == null ? '—' : formatMetricValue(metric, value!),
+          style: SnowtrakTypography.headlineSmall.copyWith(
+            color: leading ? context.colors.success : context.colors.textPrimary,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _Terms extends StatelessWidget {
+  const _Terms({required this.duel});
+
+  final Duel duel;
+
+  @override
+  Widget build(BuildContext context) {
+    return StCard(
+      padding: const EdgeInsets.all(SnowtrakSpacing.md),
+      child: Column(
+        children: [
+          _TermRow(label: 'Metric', value: duel.metric.label),
+          const SizedBox(height: SnowtrakSpacing.sm),
+          _TermRow(label: 'Duration', value: duel.duration.label),
+        ],
+      ),
+    );
+  }
+}
+
+class _TermRow extends StatelessWidget {
+  const _TermRow({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(
+          label,
+          style: SnowtrakTypography.bodyMedium.copyWith(
+            color: context.colors.textSecondary,
+          ),
+        ),
+        Text(
+          value,
+          style: SnowtrakTypography.labelLarge.copyWith(
+            color: context.colors.textPrimary,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _Status extends StatelessWidget {
+  const _Status({required this.duel, required this.viewerId});
+
+  final Duel duel;
+  final String viewerId;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text(
+        _text(DateTime.now()),
+        textAlign: TextAlign.center,
+        style: SnowtrakTypography.bodyMedium.copyWith(
+          color: context.colors.textSecondary,
+        ),
+      ),
+    );
+  }
+
+  String _text(DateTime now) {
+    switch (duel.status) {
+      case DuelStatus.pending:
+        final left = duel.answerWindowAt(now);
+        final window = left == null ? '' : ' · ${formatRemaining(left)}';
+        return duel.awaitingAnswerFrom(viewerId)
+            ? 'Waiting on you$window'
+            : 'Waiting on ${duel.otherPlayerName(viewerId)}$window';
+      case DuelStatus.active:
+        final left = duel.remainingAt(now);
+        return left == null ? 'Running' : formatRemaining(left);
+      case DuelStatus.finished:
+        if (duel.isDraw) return 'Drawn — nobody takes this one';
+        return duel.winnerId == viewerId
+            ? 'You won'
+            : '${duel.otherPlayerName(viewerId)} won';
+      case DuelStatus.declined:
+        return 'Declined';
+      case DuelStatus.cancelled:
+        return 'Withdrawn';
+      case DuelStatus.expired:
+        return 'Expired unanswered';
+    }
+  }
+}

--- a/frontend/lib/screens/leaderboard/duel_formatting.dart
+++ b/frontend/lib/screens/leaderboard/duel_formatting.dart
@@ -1,0 +1,48 @@
+import 'package:snowtrak/models/duel.dart';
+
+/// How a metric's value is written, and in what unit.
+///
+/// The server ranks in metres and km/h; the app is imperial elsewhere
+/// (`Imperial.mphFromPace` in home_stats), so the conversion happens once,
+/// here, rather than in each screen that shows a number.
+String formatMetricValue(DuelMetric metric, double value) {
+  return switch (metric) {
+    DuelMetric.vertical => '${_thousands((value * 3.28084).round())} ft',
+    DuelMetric.distance => '${(value / 1000 * 0.621371).toStringAsFixed(1)} mi',
+    DuelMetric.speed => '${(value * 0.621371).toStringAsFixed(1)} mph',
+  };
+}
+
+/// Short unit for a column header.
+String metricUnit(DuelMetric metric) => switch (metric) {
+      DuelMetric.vertical => 'ft',
+      DuelMetric.distance => 'mi',
+      DuelMetric.speed => 'mph',
+    };
+
+/// A countdown, coarsest useful unit first.
+///
+/// Deliberately not seconds: a duel runs for days, and a ticking second hand
+/// is a rebuild per second for information nobody acts on.
+String formatRemaining(Duration remaining) {
+  if (remaining <= Duration.zero) return 'Ended';
+  if (remaining.inDays >= 1) {
+    final hours = remaining.inHours % 24;
+    return '${remaining.inDays}d ${hours}h left';
+  }
+  if (remaining.inHours >= 1) {
+    final minutes = remaining.inMinutes % 60;
+    return '${remaining.inHours}h ${minutes}m left';
+  }
+  return '${remaining.inMinutes}m left';
+}
+
+String _thousands(int value) {
+  final digits = value.abs().toString();
+  final buffer = StringBuffer(value < 0 ? '-' : '');
+  for (var i = 0; i < digits.length; i++) {
+    if (i > 0 && (digits.length - i) % 3 == 0) buffer.write(',');
+    buffer.write(digits[i]);
+  }
+  return buffer.toString();
+}

--- a/frontend/lib/screens/leaderboard/duel_terms_screen.dart
+++ b/frontend/lib/screens/leaderboard/duel_terms_screen.dart
@@ -1,0 +1,223 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:snowtrak/core/errors/app_result.dart';
+import 'package:snowtrak/core/theme.dart';
+import 'package:snowtrak/models/duel.dart';
+import 'package:snowtrak/providers/duel_provider.dart';
+import 'package:snowtrak/screens/leaderboard/duel_detail_screen.dart';
+import 'package:snowtrak/ui/st/st.dart';
+
+/// Pushes the terms sheet for challenging [opponentId].
+Future<void> openDuelTerms(
+  BuildContext context, {
+  required String opponentId,
+  required String opponentName,
+}) async {
+  if (opponentId.trim().isEmpty) return;
+  await Navigator.of(context).push<void>(
+    MaterialPageRoute<void>(
+      builder: (_) => DuelTermsScreen(
+        opponentId: opponentId,
+        opponentName: opponentName,
+      ),
+    ),
+  );
+}
+
+/// Picking what a duel measures and how long it runs.
+///
+/// It does not ask when the duel starts, and cannot: the window opens when
+/// the opponent accepts. Offering a start date here would be offering a
+/// choice the server refuses to honour.
+class DuelTermsScreen extends StatefulWidget {
+  const DuelTermsScreen({
+    super.key,
+    required this.opponentId,
+    required this.opponentName,
+  });
+
+  final String opponentId;
+  final String opponentName;
+
+  @override
+  State<DuelTermsScreen> createState() => _DuelTermsScreenState();
+}
+
+class _DuelTermsScreenState extends State<DuelTermsScreen> {
+  DuelMetric _metric = DuelMetric.vertical;
+  DuelDuration _duration = DuelDuration.week;
+  bool _sending = false;
+
+  Future<void> _send() async {
+    setState(() => _sending = true);
+    final result = await context.read<DuelProvider>().challenge(
+          opponentId: widget.opponentId,
+          metric: _metric,
+          duration: _duration,
+        );
+    if (!mounted) return;
+    setState(() => _sending = false);
+
+    switch (result) {
+      case AppSuccess(:final value):
+        Navigator.of(context).pop();
+        await openDuel(context, value.id);
+      case AppFailure(:final error):
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(error.userMessage)),
+        );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: context.colors.background,
+      appBar: AppBar(
+        backgroundColor: context.colors.surface,
+        title: const Text('Set challenge terms'),
+      ),
+      body: SafeArea(
+        child: Column(
+          children: [
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.all(SnowtrakSpacing.md),
+                children: [
+                  Text(
+                    'Challenging ${widget.opponentName}',
+                    style: SnowtrakTypography.headlineSmall.copyWith(
+                      color: context.colors.textPrimary,
+                    ),
+                  ),
+                  const SizedBox(height: SnowtrakSpacing.lg),
+                  const _SectionLabel('Winning metric'),
+                  for (final option in DuelMetric.values)
+                    _OptionTile(
+                      title: option.label,
+                      subtitle: option.blurb,
+                      selected: option == _metric,
+                      onTap: () => setState(() => _metric = option),
+                    ),
+                  const SizedBox(height: SnowtrakSpacing.lg),
+                  const _SectionLabel('Battle duration'),
+                  for (final option in DuelDuration.values)
+                    _OptionTile(
+                      title: option.label,
+                      subtitle: option.blurb,
+                      selected: option == _duration,
+                      onTap: () => setState(() => _duration = option),
+                    ),
+                  const SizedBox(height: SnowtrakSpacing.smd),
+                  Text(
+                    'The clock starts when they accept. Nothing you have '
+                    'already skied counts.',
+                    style: SnowtrakTypography.bodySmall.copyWith(
+                      color: context.colors.textTertiary,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(SnowtrakSpacing.md),
+              child: SizedBox(
+                width: double.infinity,
+                height: 48,
+                child: FilledButton(
+                  onPressed: _sending ? null : _send,
+                  style: FilledButton.styleFrom(
+                    backgroundColor: context.colors.primary,
+                    foregroundColor: context.colors.textOnPrimary,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(SnowtrakRadius.md),
+                    ),
+                  ),
+                  child: Text(_sending ? 'Sending…' : 'Send challenge'),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SectionLabel extends StatelessWidget {
+  const _SectionLabel(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: SnowtrakSpacing.sm),
+      child: Text(
+        text.toUpperCase(),
+        style: SnowtrakTypography.labelSmall.copyWith(
+          color: context.colors.textTertiary,
+          letterSpacing: 0.8,
+        ),
+      ),
+    );
+  }
+}
+
+class _OptionTile extends StatelessWidget {
+  const _OptionTile({
+    required this.title,
+    required this.subtitle,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final String title;
+  final String subtitle;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: SnowtrakSpacing.sm),
+      child: StCard(
+        onTap: onTap,
+        padding: const EdgeInsets.all(SnowtrakSpacing.md),
+        child: Row(
+          children: [
+            Icon(
+              selected
+                  ? Icons.radio_button_checked
+                  : Icons.radio_button_unchecked,
+              size: 20,
+              color: selected
+                  ? context.colors.primary
+                  : context.colors.textQuaternary,
+            ),
+            const SizedBox(width: SnowtrakSpacing.smd),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: SnowtrakTypography.labelLarge.copyWith(
+                      color: context.colors.textPrimary,
+                    ),
+                  ),
+                  Text(
+                    subtitle,
+                    style: SnowtrakTypography.bodySmall.copyWith(
+                      color: context.colors.textSecondary,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/screens/leaderboard/leaderboard_tab.dart
+++ b/frontend/lib/screens/leaderboard/leaderboard_tab.dart
@@ -1,0 +1,469 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:snowtrak/core/di/service_locator.dart';
+import 'package:snowtrak/core/errors/app_result.dart';
+import 'package:snowtrak/core/theme.dart';
+import 'package:snowtrak/models/duel.dart';
+import 'package:snowtrak/models/leaderboard_entry.dart';
+import 'package:snowtrak/providers/auth_provider.dart';
+import 'package:snowtrak/providers/duel_provider.dart';
+import 'package:snowtrak/screens/leaderboard/duel_detail_screen.dart';
+import 'package:snowtrak/screens/leaderboard/duel_formatting.dart';
+import 'package:snowtrak/screens/leaderboard/duel_terms_screen.dart';
+import 'package:snowtrak/screens/profile/user_profile_screen.dart';
+import 'package:snowtrak/services/leaderboard_service.dart';
+import 'package:snowtrak/ui/st/st.dart';
+
+const String friendsScope = 'friends';
+
+/// The Community tab's leaderboard.
+///
+/// Two boards, and the difference matters: Global ranks everyone who opted
+/// an activity in, Friends ranks the people you mutually follow. Only the
+/// second carries a Challenge button, because a duel needs a mutual follow
+/// to be offered at all.
+class LeaderboardTab extends StatefulWidget {
+  const LeaderboardTab({super.key});
+
+  @override
+  State<LeaderboardTab> createState() => _LeaderboardTabState();
+}
+
+class _LeaderboardTabState extends State<LeaderboardTab> {
+  final LeaderboardService _leaderboardService = sl<LeaderboardService>();
+
+  String _scope = friendsScope;
+  DuelMetric _metric = DuelMetric.vertical;
+
+  Leaderboard? _board;
+  LeaderboardPlacing? _placing;
+  bool _isLoading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+
+    final board = await _leaderboardService.getBoard(
+      metric: _metric,
+      scope: _scope,
+    );
+    final placing = await _leaderboardService.getMyPlacing(
+      metric: _metric,
+      scope: _scope,
+    );
+    if (!mounted) return;
+
+    final viewerId = context.read<AuthProvider>().user?.id ?? '';
+    if (viewerId.isNotEmpty) {
+      await context.read<DuelProvider>().load(viewerId);
+    }
+    if (!mounted) return;
+
+    setState(() {
+      switch (board) {
+        case AppSuccess(:final value):
+          _board = value;
+          _error = null;
+        case AppFailure(:final error):
+          // No board rather than a stale one: standings that are wrong are
+          // worse than standings that are missing.
+          _board = null;
+          _error = error.userMessage;
+      }
+      _placing = placing is AppSuccess<LeaderboardPlacing> ? placing.value : null;
+      _isLoading = false;
+    });
+  }
+
+  void _select({String? scope, DuelMetric? metric}) {
+    setState(() {
+      _scope = scope ?? _scope;
+      _metric = metric ?? _metric;
+    });
+    _load();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final viewerId = context.watch<AuthProvider>().user?.id ?? '';
+    final incoming = context.watch<DuelProvider>().incoming;
+
+    return RefreshIndicator(
+      onRefresh: _load,
+      color: context.colors.primary,
+      child: ListView(
+        padding: const EdgeInsets.fromLTRB(
+          SnowtrakSpacing.md,
+          SnowtrakSpacing.md,
+          SnowtrakSpacing.md,
+          SnowtrakSpacing.xxl,
+        ),
+        children: [
+          _ScopeToggle(
+            scope: _scope,
+            onChanged: (scope) => _select(scope: scope),
+          ),
+          const SizedBox(height: SnowtrakSpacing.smd),
+          _MetricChips(
+            metric: _metric,
+            onChanged: (metric) => _select(metric: metric),
+          ),
+          if (incoming.isNotEmpty) ...[
+            const SizedBox(height: SnowtrakSpacing.md),
+            _IncomingBanner(duels: incoming, viewerId: viewerId),
+          ],
+          const SizedBox(height: SnowtrakSpacing.md),
+          _PlacingCard(metric: _metric, placing: _placing),
+          const SizedBox(height: SnowtrakSpacing.md),
+          ..._boardBody(viewerId),
+        ],
+      ),
+    );
+  }
+
+  List<Widget> _boardBody(String viewerId) {
+    if (_isLoading) {
+      return const [
+        Padding(
+          padding: EdgeInsets.only(top: SnowtrakSpacing.xl),
+          child: Center(child: CircularProgressIndicator()),
+        ),
+      ];
+    }
+    final error = _error;
+    if (error != null) {
+      return [_BoardMessage(message: error, onRetry: _load)];
+    }
+    final entries = _board?.entries ?? const <LeaderboardEntry>[];
+    if (entries.isEmpty) {
+      return [
+        _BoardMessage(
+          message: _scope == friendsScope
+              ? 'Nobody you follow has put an activity on the board this week.'
+              : 'No activities on the board this week yet.',
+          onRetry: _load,
+        ),
+      ];
+    }
+    return entries
+        .map(
+          (entry) => Padding(
+            padding: const EdgeInsets.only(bottom: SnowtrakSpacing.sm),
+            child: _BoardRow(
+              entry: entry,
+              metric: _metric,
+              // Only the friends board can offer a duel.
+              challengeable: _scope == friendsScope && entry.userId != viewerId,
+            ),
+          ),
+        )
+        .toList();
+  }
+}
+
+class _ScopeToggle extends StatelessWidget {
+  const _ScopeToggle({required this.scope, required this.onChanged});
+
+  final String scope;
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(SnowtrakSpacing.xs),
+      decoration: BoxDecoration(
+        color: context.colors.surfaceVariant,
+        borderRadius: BorderRadius.circular(SnowtrakRadius.md),
+      ),
+      child: Row(
+        children: [
+          _ToggleHalf(
+            label: 'Friends',
+            selected: scope == friendsScope,
+            onTap: () => onChanged(friendsScope),
+          ),
+          _ToggleHalf(
+            label: 'Global',
+            selected: scope == globalScope,
+            onTap: () => onChanged(globalScope),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ToggleHalf extends StatelessWidget {
+  const _ToggleHalf({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: GestureDetector(
+        onTap: onTap,
+        behavior: HitTestBehavior.opaque,
+        child: Container(
+          height: 36,
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: selected ? context.colors.surface : Colors.transparent,
+            borderRadius: BorderRadius.circular(SnowtrakRadius.sm),
+          ),
+          child: Text(
+            label,
+            style: SnowtrakTypography.labelLarge.copyWith(
+              color: selected
+                  ? context.colors.textPrimary
+                  : context.colors.textSecondary,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MetricChips extends StatelessWidget {
+  const _MetricChips({required this.metric, required this.onChanged});
+
+  final DuelMetric metric;
+  final ValueChanged<DuelMetric> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 36,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        itemCount: DuelMetric.values.length,
+        separatorBuilder: (_, __) => const SizedBox(width: SnowtrakSpacing.sm),
+        itemBuilder: (context, index) {
+          final option = DuelMetric.values[index];
+          final selected = option == metric;
+          return ChoiceChip(
+            selected: selected,
+            onSelected: (_) => onChanged(option),
+            label: Text(option.label),
+            labelStyle: SnowtrakTypography.labelMedium.copyWith(
+              color: selected
+                  ? context.colors.textOnPrimary
+                  : context.colors.textSecondary,
+            ),
+            selectedColor: context.colors.primary,
+            backgroundColor: context.colors.surfaceVariant,
+            showCheckmark: false,
+            side: BorderSide(color: context.colors.border),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _IncomingBanner extends StatelessWidget {
+  const _IncomingBanner({required this.duels, required this.viewerId});
+
+  final List<Duel> duels;
+  final String viewerId;
+
+  @override
+  Widget build(BuildContext context) {
+    final first = duels.first;
+    final more = duels.length - 1;
+    return StCard(
+      color: context.colors.primary,
+      padding: const EdgeInsets.all(SnowtrakSpacing.md),
+      onTap: () => openDuel(context, first.id),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  more > 0
+                      ? '${duels.length} battle challenges'
+                      : 'New battle challenge',
+                  style: SnowtrakTypography.labelLarge.copyWith(
+                    color: context.colors.textOnPrimary,
+                  ),
+                ),
+                const SizedBox(height: SnowtrakSpacing.xxs),
+                Text(
+                  '${first.otherPlayerName(viewerId)} · '
+                  '${first.metric.label}',
+                  style: SnowtrakTypography.bodySmall.copyWith(
+                    color: context.colors.textOnPrimary.withValues(alpha: 0.8),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Icon(Icons.chevron_right, color: context.colors.textOnPrimary),
+        ],
+      ),
+    );
+  }
+}
+
+class _PlacingCard extends StatelessWidget {
+  const _PlacingCard({required this.metric, required this.placing});
+
+  final DuelMetric metric;
+  final LeaderboardPlacing? placing;
+
+  @override
+  Widget build(BuildContext context) {
+    final rank = placing?.rank;
+    return StCard(
+      padding: const EdgeInsets.all(SnowtrakSpacing.md),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Your position',
+                  style: SnowtrakTypography.labelMedium.copyWith(
+                    color: context.colors.textSecondary,
+                  ),
+                ),
+                const SizedBox(height: SnowtrakSpacing.xxs),
+                Text(
+                  rank == null
+                      ? 'Not on the board yet'
+                      : formatMetricValue(metric, placing?.value ?? 0),
+                  style: SnowtrakTypography.headlineSmall.copyWith(
+                    color: context.colors.textPrimary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Text(
+            rank == null ? '—' : '#$rank',
+            style: SnowtrakTypography.metricMedium.copyWith(
+              color: context.colors.primary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BoardRow extends StatelessWidget {
+  const _BoardRow({
+    required this.entry,
+    required this.metric,
+    required this.challengeable,
+  });
+
+  final LeaderboardEntry entry;
+  final DuelMetric metric;
+  final bool challengeable;
+
+  @override
+  Widget build(BuildContext context) {
+    return StCard(
+      padding: const EdgeInsets.symmetric(
+        horizontal: SnowtrakSpacing.md,
+        vertical: SnowtrakSpacing.smd,
+      ),
+      onTap: () => openUserProfile(
+        context,
+        entry.userId,
+        displayName: entry.displayName,
+        username: entry.username,
+      ),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 28,
+            child: Text(
+              '${entry.rank}',
+              style: SnowtrakTypography.labelLarge.copyWith(
+                color: context.colors.textTertiary,
+              ),
+            ),
+          ),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  entry.displayName,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: SnowtrakTypography.labelLarge.copyWith(
+                    color: context.colors.textPrimary,
+                  ),
+                ),
+                Text(
+                  formatMetricValue(metric, entry.value),
+                  style: SnowtrakTypography.bodySmall.copyWith(
+                    color: context.colors.textSecondary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          if (challengeable)
+            TextButton(
+              onPressed: () => openDuelTerms(
+                context,
+                opponentId: entry.userId,
+                opponentName: entry.displayName,
+              ),
+              child: const Text('Challenge'),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BoardMessage extends StatelessWidget {
+  const _BoardMessage({required this.message, required this.onRetry});
+
+  final String message;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: SnowtrakSpacing.xl),
+      child: Column(
+        children: [
+          Text(
+            message,
+            textAlign: TextAlign.center,
+            style: SnowtrakTypography.bodyMedium.copyWith(
+              color: context.colors.textSecondary,
+            ),
+          ),
+          const SizedBox(height: SnowtrakSpacing.smd),
+          TextButton(onPressed: onRetry, child: const Text('Retry')),
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/lib/screens/notifications/notifications_screen.dart
+++ b/frontend/lib/screens/notifications/notifications_screen.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:snowtrak/core/theme.dart';
 import 'package:snowtrak/models/notification.dart';
+import 'package:snowtrak/providers/auth_provider.dart';
 import 'package:snowtrak/providers/notification_provider.dart';
+import 'package:snowtrak/screens/leaderboard/duel_detail_screen.dart';
 import 'package:snowtrak/screens/profile/user_profile_screen.dart';
 import 'package:snowtrak/services/notification_service.dart';
 
@@ -18,9 +20,7 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
   void initState() {
     super.initState();
     // Load notifications when screen opens
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      context.read<NotificationProvider>().loadNotifications();
-    });
+    WidgetsBinding.instance.addPostFrameCallback((_) => _reload());
   }
 
   @override
@@ -198,7 +198,7 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
             ),
             const SizedBox(height: SnowtrakSpacing.lg),
             ElevatedButton(
-              onPressed: () => provider.loadNotifications(),
+              onPressed: _reload,
               child: const Text('Retry'),
             ),
           ],
@@ -207,19 +207,40 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
     );
   }
 
+  /// Rebuilds the list, telling the provider who is looking.
+  ///
+  /// A pending duel is only a notification for the person being challenged;
+  /// without the viewer the provider cannot tell those apart and reads
+  /// follow requests alone.
+  Future<void> _reload() async {
+    final viewerId = context.read<AuthProvider>().user?.id;
+    await context
+        .read<NotificationProvider>()
+        .loadNotifications(viewerId: viewerId);
+  }
+
   Future<void> _handleNotificationTap(AppNotification notification) async {
     context.read<NotificationProvider>().markAsRead(notification.id);
 
-    // Every notification is a follow request today, so the tap goes to the
-    // requester's profile -- where the Follow button and their runs are, which
-    // is what you need to decide whether to approve.
-    final userId = notification.metadata?['user_id'] as String? ?? '';
-    if (userId.isEmpty) return;
-
-    await openUserProfile(context, userId, displayName: notification.senderName);
-    // Approving or denying from the profile clears the request, so the list
-    // behind this screen is stale exactly on the way back.
-    if (mounted) await context.read<NotificationProvider>().loadNotifications();
+    // Two kinds, two destinations. A duel opens the duel -- the accept and
+    // decline buttons are there. A follow request opens the requester's
+    // profile, where the Follow button and their runs are, which is what you
+    // need to decide whether to approve.
+    final duelId = notification.metadata?['duel_id'] as String? ?? '';
+    if (duelId.isNotEmpty) {
+      await openDuel(context, duelId);
+    } else {
+      final userId = notification.metadata?['user_id'] as String? ?? '';
+      if (userId.isEmpty) return;
+      await openUserProfile(
+        context,
+        userId,
+        displayName: notification.senderName,
+      );
+    }
+    // Answering either one clears it, so the list behind this screen is
+    // stale exactly on the way back.
+    if (mounted) await _reload();
   }
 
   void _handleNotificationDismiss(AppNotification notification) {

--- a/frontend/lib/services/apis/duel_api.dart
+++ b/frontend/lib/services/apis/duel_api.dart
@@ -1,0 +1,86 @@
+import 'package:dio/dio.dart';
+import 'package:snowtrak/models/duel.dart';
+
+/// `/api/v1/duels` on activity-backend.
+class DuelApi {
+  DuelApi({required Dio dio}) : _dio = dio;
+
+  final Dio _dio;
+
+  /// Challenges someone who follows you back.
+  ///
+  /// The window is not sent: it opens when the opponent accepts, which is
+  /// what keeps it non-retroactive.
+  Future<Duel> create({
+    required String opponentId,
+    required DuelMetric metric,
+    required DuelDuration duration,
+  }) =>
+      _one(
+        () => _dio.post<Map<String, dynamic>>(
+          '/duels',
+          data: {
+            'opponent_id': opponentId,
+            'metric': metric.value,
+            'duration': duration.value,
+          },
+        ),
+      );
+
+  Future<List<Duel>> list({
+    DuelStatus? status,
+    int limit = 20,
+    int offset = 0,
+  }) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/duels',
+      queryParameters: {
+        if (status != null) 'status': status.name,
+        'limit': limit,
+        'offset': offset,
+      },
+    );
+    final items = response.data?['items'];
+    if (items is! List) {
+      throw const FormatException('Duel list response had no items');
+    }
+    return items
+        .whereType<Map<String, dynamic>>()
+        .map(Duel.fromJson)
+        .toList();
+  }
+
+  Future<Duel> get(String duelId) =>
+      _one(() => _dio.get<Map<String, dynamic>>('/duels/$duelId'));
+
+  Future<Duel> accept(String duelId) =>
+      _one(() => _dio.post<Map<String, dynamic>>('/duels/$duelId/accept'));
+
+  Future<Duel> decline(String duelId) =>
+      _one(() => _dio.post<Map<String, dynamic>>('/duels/$duelId/decline'));
+
+  /// Withdraws a challenge the opponent has not answered.
+  Future<Duel> cancel(String duelId) =>
+      _one(() => _dio.delete<Map<String, dynamic>>('/duels/$duelId'));
+
+  Future<DuelRecord> record(String userId) async {
+    final response =
+        await _dio.get<Map<String, dynamic>>('/users/$userId/duel_record');
+    final data = response.data;
+    if (data == null) {
+      throw const FormatException('Duel record response was empty');
+    }
+    return DuelRecord.fromJson(data);
+  }
+
+  Future<Duel> _one(
+    Future<Response<Map<String, dynamic>>> Function() request,
+  ) async {
+    final response = await request();
+    final data = response.data;
+    if (data == null) {
+      throw const FormatException('Duel response was empty');
+    }
+    return Duel.fromJson(data);
+  }
+}

--- a/frontend/lib/services/apis/leaderboard_api.dart
+++ b/frontend/lib/services/apis/leaderboard_api.dart
@@ -1,0 +1,70 @@
+import 'package:dio/dio.dart';
+import 'package:snowtrak/models/duel.dart';
+import 'package:snowtrak/models/leaderboard_entry.dart';
+
+/// `/api/v1/leaderboard` on activity-backend.
+///
+/// The board aggregates `activities`, so it lives with the activities, not
+/// with the follow graph. See docs/service-ownership.md.
+class LeaderboardApi {
+  LeaderboardApi({required Dio dio}) : _dio = dio;
+
+  final Dio _dio;
+
+  Future<Leaderboard> getBoard({
+    DuelMetric metric = DuelMetric.vertical,
+    String scope = globalScope,
+    int limit = 50,
+  }) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/leaderboard',
+      queryParameters: {
+        'metric': metric.value,
+        'scope': scope,
+        'limit': limit,
+      },
+    );
+    final data = response.data;
+    if (data == null) {
+      throw const FormatException('Leaderboard response was empty');
+    }
+    return Leaderboard.fromJson(data);
+  }
+
+  /// A settled week. [week] is the ISO date of its Monday.
+  Future<Leaderboard> getWeek(
+    String week, {
+    DuelMetric metric = DuelMetric.vertical,
+    String scope = globalScope,
+    int limit = 50,
+  }) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/leaderboard/weeks/$week',
+      queryParameters: {
+        'metric': metric.value,
+        'scope': scope,
+        'limit': limit,
+      },
+    );
+    final data = response.data;
+    if (data == null) {
+      throw const FormatException('Leaderboard week response was empty');
+    }
+    return Leaderboard.fromJson(data);
+  }
+
+  Future<LeaderboardPlacing> getMyPlacing({
+    DuelMetric metric = DuelMetric.vertical,
+    String scope = globalScope,
+  }) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/leaderboard/me',
+      queryParameters: {'metric': metric.value, 'scope': scope},
+    );
+    final data = response.data;
+    if (data == null) {
+      throw const FormatException('Leaderboard placing response was empty');
+    }
+    return LeaderboardPlacing.fromJson(data);
+  }
+}

--- a/frontend/lib/services/duel_service.dart
+++ b/frontend/lib/services/duel_service.dart
@@ -1,0 +1,51 @@
+import 'package:snowtrak/core/errors/app_error.dart';
+import 'package:snowtrak/core/errors/app_result.dart';
+import 'package:snowtrak/models/duel.dart';
+import 'package:snowtrak/services/apis/duel_api.dart';
+
+/// ponytail: no repository layer, matching FollowService.
+class DuelService {
+  DuelService({required DuelApi duelApi}) : _api = duelApi;
+
+  final DuelApi _api;
+
+  Future<AppResult<Duel>> challenge({
+    required String opponentId,
+    required DuelMetric metric,
+    required DuelDuration duration,
+  }) =>
+      _run(() => _api.create(
+            opponentId: opponentId,
+            metric: metric,
+            duration: duration,
+          ));
+
+  Future<AppResult<List<Duel>>> list({
+    DuelStatus? status,
+    int limit = 20,
+    int offset = 0,
+  }) =>
+      _run(() => _api.list(status: status, limit: limit, offset: offset));
+
+  Future<AppResult<Duel>> get(String duelId) => _run(() => _api.get(duelId));
+
+  Future<AppResult<Duel>> accept(String duelId) =>
+      _run(() => _api.accept(duelId));
+
+  Future<AppResult<Duel>> decline(String duelId) =>
+      _run(() => _api.decline(duelId));
+
+  Future<AppResult<Duel>> cancel(String duelId) =>
+      _run(() => _api.cancel(duelId));
+
+  Future<AppResult<DuelRecord>> record(String userId) =>
+      _run(() => _api.record(userId));
+
+  Future<AppResult<T>> _run<T>(Future<T> Function() fn) async {
+    try {
+      return AppSuccess(await fn());
+    } catch (e, st) {
+      return AppFailure(AppError.from(e, st));
+    }
+  }
+}

--- a/frontend/lib/services/leaderboard_service.dart
+++ b/frontend/lib/services/leaderboard_service.dart
@@ -1,0 +1,43 @@
+import 'package:snowtrak/core/errors/app_error.dart';
+import 'package:snowtrak/core/errors/app_result.dart';
+import 'package:snowtrak/models/duel.dart';
+import 'package:snowtrak/models/leaderboard_entry.dart';
+import 'package:snowtrak/services/apis/leaderboard_api.dart';
+
+/// ponytail: no repository layer, matching FollowService. Add one if the
+/// board ever needs an offline cache.
+class LeaderboardService {
+  LeaderboardService({required LeaderboardApi leaderboardApi})
+      : _api = leaderboardApi;
+
+  final LeaderboardApi _api;
+
+  Future<AppResult<Leaderboard>> getBoard({
+    DuelMetric metric = DuelMetric.vertical,
+    String scope = globalScope,
+    int limit = 50,
+  }) =>
+      _run(() => _api.getBoard(metric: metric, scope: scope, limit: limit));
+
+  Future<AppResult<Leaderboard>> getWeek(
+    String week, {
+    DuelMetric metric = DuelMetric.vertical,
+    String scope = globalScope,
+    int limit = 50,
+  }) =>
+      _run(() => _api.getWeek(week, metric: metric, scope: scope, limit: limit));
+
+  Future<AppResult<LeaderboardPlacing>> getMyPlacing({
+    DuelMetric metric = DuelMetric.vertical,
+    String scope = globalScope,
+  }) =>
+      _run(() => _api.getMyPlacing(metric: metric, scope: scope));
+
+  Future<AppResult<T>> _run<T>(Future<T> Function() fn) async {
+    try {
+      return AppSuccess(await fn());
+    } catch (e, st) {
+      return AppFailure(AppError.from(e, st));
+    }
+  }
+}

--- a/frontend/test/models/duel_test.dart
+++ b/frontend/test/models/duel_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:snowtrak/models/duel.dart';
+import 'package:snowtrak/screens/leaderboard/duel_formatting.dart';
+
+Duel _duel({
+  DuelStatus status = DuelStatus.pending,
+  DateTime? createdAt,
+  DateTime? endsAt,
+  String? winnerId,
+}) {
+  return Duel(
+    id: 'duel-1',
+    challengerId: 'alex',
+    opponentId: 'jordan',
+    metric: DuelMetric.vertical,
+    duration: DuelDuration.week,
+    status: status,
+    createdAt: createdAt ?? DateTime.utc(2026, 9, 2, 12),
+    endsAt: endsAt,
+    winnerId: winnerId,
+  );
+}
+
+void main() {
+  final now = DateTime.utc(2026, 9, 2, 12);
+
+  group('who is being asked', () {
+    test('only the challenged player is waiting to answer', () {
+      final duel = _duel();
+      expect(duel.awaitingAnswerFrom('jordan'), isTrue);
+      expect(duel.awaitingAnswerFrom('alex'), isFalse);
+      expect(duel.awaitingAnswerFor('alex'), isTrue);
+    });
+
+    test('an accepted duel is nobody to answer for', () {
+      final duel = _duel(status: DuelStatus.active);
+      expect(duel.awaitingAnswerFrom('jordan'), isFalse);
+      expect(duel.awaitingAnswerFor('alex'), isFalse);
+    });
+  });
+
+  group('countdowns', () {
+    test('a closed window reads as zero, never as time running backwards', () {
+      final duel = _duel(
+        status: DuelStatus.active,
+        endsAt: now.subtract(const Duration(hours: 3)),
+      );
+      expect(duel.remainingAt(now), Duration.zero);
+      expect(formatRemaining(duel.remainingAt(now)!), 'Ended');
+    });
+
+    test('a pending challenge counts down from the 48 hour invite window', () {
+      final duel = _duel(createdAt: now.subtract(const Duration(hours: 47)));
+      expect(duel.answerWindowAt(now), const Duration(hours: 1));
+    });
+
+    test('a duel with no window has no countdown', () {
+      expect(_duel().remainingAt(now), isNull);
+      expect(_duel(status: DuelStatus.finished).answerWindowAt(now), isNull);
+    });
+  });
+
+  group('results', () {
+    test('a finished duel with no winner is a draw, not a loss', () {
+      expect(_duel(status: DuelStatus.finished).isDraw, isTrue);
+      expect(
+        _duel(status: DuelStatus.finished, winnerId: 'alex').isDraw,
+        isFalse,
+      );
+      // Pending with no winner is not a draw -- it has not been played.
+      expect(_duel().isDraw, isFalse);
+    });
+
+    test('a record with nothing played has no win rate rather than zero', () {
+      expect(const DuelRecord().winRate, isNull);
+      expect(const DuelRecord(wins: 1, losses: 1).winRate, 0.5);
+    });
+  });
+
+  group('decoding', () {
+    test('an unknown metric falls back rather than throwing', () {
+      // A newer server can add one; a crash on the list screen is worse
+      // than showing the default.
+      final duel = Duel.fromJson({
+        'id': 'd',
+        'challenger_id': 'alex',
+        'opponent_id': 'jordan',
+        'metric': 'most_runs',
+        'duration': 'week',
+        'status': 'active',
+        'created_at': '2026-09-02T12:00:00Z',
+      });
+      expect(duel.metric, DuelMetric.vertical);
+      expect(duel.status, DuelStatus.active);
+    });
+  });
+
+  group('formatting', () {
+    test('vertical is shown in feet, thousands separated', () {
+      expect(formatMetricValue(DuelMetric.vertical, 1000), '3,281 ft');
+    });
+
+    test('speed converts km/h to mph', () {
+      expect(formatMetricValue(DuelMetric.speed, 100), '62.1 mph');
+    });
+  });
+}

--- a/frontend/test/providers/notification_provider_test.dart
+++ b/frontend/test/providers/notification_provider_test.dart
@@ -2,9 +2,12 @@ import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:snowtrak/core/errors/app_error.dart';
 import 'package:snowtrak/core/errors/app_result.dart';
+import 'package:snowtrak/models/duel.dart';
 import 'package:snowtrak/models/notification.dart';
 import 'package:snowtrak/providers/notification_provider.dart';
+import 'package:snowtrak/services/apis/duel_api.dart';
 import 'package:snowtrak/services/apis/follow_api.dart';
+import 'package:snowtrak/services/duel_service.dart';
 import 'package:snowtrak/services/follow_service.dart';
 
 class _FakeFollowService extends FollowService {
@@ -24,13 +27,50 @@ class _FakeFollowService extends FollowService {
   }
 }
 
+class _FakeDuelService extends DuelService {
+  _FakeDuelService() : super(duelApi: DuelApi(dio: Dio()));
+
+  List<Duel> duels = <Duel>[];
+
+  @override
+  Future<AppResult<List<Duel>>> list({
+    DuelStatus? status,
+    int limit = 20,
+    int offset = 0,
+  }) async =>
+      AppSuccess(duels);
+}
+
+Duel _pendingDuel({
+  required String challengerId,
+  required String opponentId,
+  required DateTime createdAt,
+  String? challengerName,
+}) {
+  return Duel(
+    id: 'duel-1',
+    challengerId: challengerId,
+    opponentId: opponentId,
+    metric: DuelMetric.vertical,
+    duration: DuelDuration.week,
+    status: DuelStatus.pending,
+    createdAt: createdAt,
+    challengerName: challengerName,
+  );
+}
+
 void main() {
   late _FakeFollowService service;
+  late _FakeDuelService duelService;
   late NotificationProvider provider;
 
   setUp(() {
     service = _FakeFollowService();
-    provider = NotificationProvider(followService: service);
+    duelService = _FakeDuelService();
+    provider = NotificationProvider(
+      followService: service,
+      duelService: duelService,
+    );
   });
 
   test('carries the requester id in metadata, so a tap can open the profile',
@@ -84,5 +124,82 @@ void main() {
 
     expect(provider.error, 'No connection');
     expect(provider.hasUnread, isFalse);
+  });
+
+  test('a pending duel you were challenged to becomes a notification',
+      () async {
+    duelService.duels = [
+      _pendingDuel(
+        challengerId: 'sam',
+        opponentId: 'me',
+        createdAt: DateTime.utc(2026, 9, 1, 10),
+        challengerName: 'Sam Park',
+      ),
+    ];
+
+    await provider.loadNotifications(viewerId: 'me');
+
+    final notification = provider.notifications.single;
+    expect(notification.type, NotificationType.challenge);
+    expect(notification.metadata?['duel_id'], 'duel-1');
+    expect(notification.message, contains('Sam Park'));
+  });
+
+  test('a duel you sent is not a notification for you', () async {
+    // It is something you are waiting on, not something to answer.
+    duelService.duels = [
+      _pendingDuel(
+        challengerId: 'me',
+        opponentId: 'sam',
+        createdAt: DateTime.utc(2026, 9, 1, 10),
+      ),
+    ];
+
+    await provider.loadNotifications(viewerId: 'me');
+
+    expect(provider.notifications, isEmpty);
+  });
+
+  test('without a viewer only follow requests are read', () async {
+    // App start, before auth resolves: the provider cannot tell an incoming
+    // duel from an outgoing one, so it reads neither.
+    duelService.duels = [
+      _pendingDuel(
+        challengerId: 'sam',
+        opponentId: 'me',
+        createdAt: DateTime.utc(2026, 9, 1, 10),
+      ),
+    ];
+    service.requests = [
+      {'user_id': 'abc-123', 'first_name': 'Mei'},
+    ];
+
+    await provider.loadNotifications();
+
+    expect(provider.notifications.single.type, NotificationType.follow);
+  });
+
+  test('the two sources interleave newest first', () async {
+    service.requests = [
+      {
+        'user_id': 'abc-123',
+        'first_name': 'Mei',
+        'created_at': '2026-09-01T08:00:00Z',
+      },
+    ];
+    duelService.duels = [
+      _pendingDuel(
+        challengerId: 'sam',
+        opponentId: 'me',
+        createdAt: DateTime.utc(2026, 9, 1, 12),
+      ),
+    ];
+
+    await provider.loadNotifications(viewerId: 'me');
+
+    expect(
+      provider.notifications.map((n) => n.type),
+      [NotificationType.challenge, NotificationType.follow],
+    );
   });
 }


### PR DESCRIPTION
Two competition modes that reduce to one question of `activities`: sum one
column, for one user, over one window. The leaderboard drops the user filter
and adds a `GROUP BY`; everything else is packaging.

Design: [`docs/superpowers/specs/2026-09-02-duel-and-leaderboard-design.md`](docs/superpowers/specs/2026-09-02-duel-and-leaderboard-design.md)

## What ships

- **Global leaderboard** — three scopes (`global`, `friends`, ISO-2 country),
  three metrics (vertical, top speed, distance), settling weekly into a
  top-100 snapshot. Opt-in is per activity.
- **Friend duels** — 1v1 between two people who follow each other. Pick a
  metric and a duration; the window opens when the challenge is accepted.
  Win/loss record, no points and no tiers.
- **Community tab** — `Threads | Leaderboards`. The mock `Challenges` tab is
  replaced; `Activity`, `Clubs` and `Trails` stop being mounted and stay on
  disk, since they are mock screens with no backend and deleting them is a
  separate cleanup.
- **Duel invitations** join pending follow requests as a second source in
  `NotificationProvider`.

## Migrations — already applied

`019`, `020` and `021` were run against the live database on 2026-09-02 and
verified end to end (below). All three are additive, so `main`, `develop` and
`stage` are safe running against that schema without this code: they simply
have tables nothing reads.

`docs/database_schema.md` has **not** been regenerated. It should be, with
`.venv/bin/python scripts/dump_supabase_schema.py`, before this reaches main.

## The decisions worth reading

**Asynchronous, not live.** No WebSocket, no presence, no GPS streaming.
None of it exists in the app and none of it survives a mountain with no
signal.

**Mutual follow gates a duel**, reusing `follows` and `can_read_account`
rather than inventing a second relationship and a second harassment surface.
That is also why the Challenge button appears only on the Friends board:
anywhere else it would 403.

**`starts_at` is written at acceptance, for both players.** Symmetric and
non-retroactive, which removes the cheat of challenging someone to "today
only" after a big morning.

**A duel ignores the leaderboard opt-in; the board honours it.** Same column,
two different questions. The opponent is a friend, and a private match should
not require publishing anything.

**Settlement rides the `PipelineWorker` pattern** already in
activity-backend's lifespan. No new dependency, no cron, no scheduled
workflow. Idempotence comes from the snapshot primary key and a
status-conditional update, so a lazy settle on read and the background sweep
race harmlessly and it is safe on more than one replica.

**The one line to read twice** is `score` in
`domain/competition/metrics.py`. `activities.max_pace` is seconds per
kilometre, so the fastest run is the *smallest* positive value, and the
column defaults to `0` when there is no reading rather than meaning
infinitely fast. Scoring it as a max, as a sum, or without excluding the
zeroes all put everyone who never recorded a speed at the top of the board.

## Two corrections made during review

**The mockups have a Friends/Global toggle the spec did not.** Not cosmetic:
without a friends board the Challenge button has nowhere to stand. Added as a
third scope, with all three resolving through one SQL predicate
(`leaderboard_in_scope`) so the board, the placing and the snapshot cannot
drift apart about who is on a board.

**019 and 020 read the wrong table.** They hung display names and
`country_code` off `profiles`, which is empty and stays empty — its `id`
references Supabase auth's `users` while registration writes `user_info`, so
`create_profile` fails with 23503 every time. Testing the API against the
running stack found every player named "Skier" and would have found a country
board silently empty forever. `021` moves both to `user_info`, and
`PUT /api/v1/users/me/country` mirrors `/me/privacy`, which is the working
precedent for a setting that has to land there. Tracked as #43.

## Verified against the running stack

Two throwaway accounts, then a real activity, then cleaned up:

- 15/15 API checks: country write and read-back, three scopes, `/me`, a
  settled week, 422 on a bad scope, 401 without a token, 403 without a mutual
  follow, 422 self-challenge, 201 create, 409 duplicate, accept, 409 withdraw
  after accept, duel record
- Scores: vertical `1500`, distance `12000`, speed `60.0` (60 s/km inverted
  to 60 km/h). `CH` board populated, `US` empty, friends board resolved from
  the other player's side
- `on_leaderboard=false` through the API empties the board; `activity_total`
  still returns the same numbers, which is the duel-vs-board split working
- A second run with `max_pace = 0` left the speed board at `60.0` and moved
  vertical to `1510` — the zero is a missing reading, not an infinite speed
- Test rows and all four accounts deleted afterwards

## Checks

| | |
|---|---|
| `ruff check backend/` | clean |
| `ruff format --check` | clean for every file touched |
| activity-backend | 71 passed |
| main-backend | 54 passed, 1 skipped |
| community-backend | 113 passed |
| `flutter test` | 69 passed |
| `dart analyze lib/ test/` | no issues |
| `flutter analyze` | **exits 64 on this machine** — a pre-existing toolchain fault, not these files. `dart analyze` was run instead |

`scripts/check_secrets.sh` reports two hits, both pre-existing and neither in
this diff: an example JWT in `docs/playbook/auth-flow/README.md` whose
signature is the literal string `signature`, and the scanner's own pattern
list.

## Deliberately not here

LP and ranked tiers (the mockups show a full ladder — it is a rating system,
not a column), Most Runs (nothing counts runs), resort scope (`ski_resorts`
was dropped in `007`), and the country picker UI (#44).

## Follow-ups filed

- #43 — `profiles` cannot be written, so profile edits 500 and avatars are lost
- #44 — no country picker, so every country board is empty
- #45 — no way to delete an account, which blocks App Store review 5.1.1(v)
