### PR TITLE
fix(profiles): repair the profiles table and its avatar/identity paths

### DIFF
--- a/backend/activity-backend/routes/duel_routes.py
+++ b/backend/activity-backend/routes/duel_routes.py
@@ -9,6 +9,7 @@ import logging
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from shared.display_name import UNKNOWN_PLAYER
 
 from domain.competition.duel import Duel, DuelStatus
 from middleware.auth import get_current_user
@@ -24,7 +25,6 @@ from services.duel_operations import (
     NotEligible,
     get_duel_operations,
 )
-from services.leaderboard_operations import UNKNOWN_PLAYER
 from services.offload import offload
 
 logger = logging.getLogger(__name__)

--- a/backend/activity-backend/services/duel_operations.py
+++ b/backend/activity-backend/services/duel_operations.py
@@ -170,7 +170,7 @@ class DuelOperations:
         try:
             response = (
                 self._client.table("user_info")
-                .select("id,first_name,last_name,email")
+                .select("id,username,first_name,last_name,email")
                 .in_("id", ids)
                 .execute()
             )

--- a/backend/activity-backend/services/leaderboard_operations.py
+++ b/backend/activity-backend/services/leaderboard_operations.py
@@ -13,17 +13,14 @@ import logging
 from datetime import UTC, date, datetime
 from typing import Any
 
+from shared.display_name import display_name
+
 from domain.competition.metrics import Metric, week_bounds, week_start
 
 logger = logging.getLogger(__name__)
 
 GLOBAL_SCOPE = "global"
 FRIENDS_SCOPE = "friends"
-
-#: Shown for a user with no name and no email handle. One placeholder, used
-#: by the board and by duel cards, so an unknown player reads the same way in
-#: both places.
-UNKNOWN_PLAYER = "Skier"
 
 #: A board page. Deep paging into a leaderboard is not a use anyone has;
 #: someone looking for their own row uses `placing` instead.
@@ -65,7 +62,7 @@ class LeaderboardOperations:
     # `profiles.id` references Supabase auth's users while registration
     # writes `user_info`, so create_profile fails with 23503 every time.
     # main-backend renders profiles from `user_info` for the same reason.
-    _USER_COLUMNS = "id,first_name,last_name,email,country_code"
+    _USER_COLUMNS = "id,username,first_name,last_name,email,country_code"
 
     def __init__(self, client) -> None:
         self._client = client
@@ -297,22 +294,20 @@ def display_fields(user: dict[str, Any]) -> dict[str, Any]:
     what lets a private activity count towards a total without leaking
     anything about itself.
 
-    Name, then email handle, then a placeholder -- the same ladder the follow
-    request list already uses, so one person is named the same way in both.
-
     ponytail: avatar_url is always null. Uploaded avatars are written to
-    `profiles.avatar_url`, and that row never exists, so no avatar URL is
-    persisted anywhere in this database -- issue #43. Fill it in when that is
-    fixed; do not invent a second place to keep it.
+    `profiles.avatar_url`, and until migration 022 that row never existed --
+    issue #43. Fill it in when the community payload carries an avatar; do
+    not invent a second place to keep it.
     """
-    first = (user.get("first_name") or "").strip()
-    last = (user.get("last_name") or "").strip()
-    full = " ".join(part for part in (first, last) if part)
-    email = (user.get("email") or "").strip()
-    handle = email.split("@")[0] if "@" in email else None
+    username = (user.get("username") or "").strip() or None
     return {
-        "display_name": full or handle or UNKNOWN_PLAYER,
-        "username": handle,
+        "display_name": display_name(
+            username=username,
+            first_name=user.get("first_name"),
+            last_name=user.get("last_name"),
+            email=user.get("email"),
+        ),
+        "username": username,
         "avatar_url": None,
         "country_code": user.get("country_code"),
     }

--- a/backend/activity-backend/tests/test_competition_operations.py
+++ b/backend/activity-backend/tests/test_competition_operations.py
@@ -320,6 +320,24 @@ class TestLeaderboard:
 
         assert entry["display_name"] == "skier"
 
+    def test_a_chosen_username_is_what_the_board_shows(self):
+        client = _FakeClient()
+        client.rpc_results["leaderboard_top"] = [{"rank": 1, "user_id": ALEX, "value": 900.0}]
+        client.rows["user_info"] = [
+            {
+                "id": ALEX,
+                "username": "snowking",
+                "first_name": "Alpha",
+                "last_name": "Tester",
+                "email": "alpha@example.com",
+            }
+        ]
+
+        entry = LeaderboardOperations(client).top(Metric.VERTICAL, GLOBAL_SCOPE, NOW)[0]
+
+        assert entry["display_name"] == "@snowking"
+        assert entry["username"] == "snowking"
+
     def test_the_board_window_is_the_monday_of_that_week(self):
         client = _FakeClient()
         LeaderboardOperations(client).top(Metric.SPEED, GLOBAL_SCOPE, NOW)

--- a/backend/activity-backend/tests/test_duel_routes.py
+++ b/backend/activity-backend/tests/test_duel_routes.py
@@ -6,7 +6,7 @@ duels they returned had null names. Nothing failed -- a null name renders
 as a blank. The route is the only layer where that is visible.
 """
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -14,7 +14,10 @@ import services.duel_operations as duel_operations
 from domain.competition.duel import Duel, DuelStatus
 from domain.competition.metrics import Duration, Metric
 
-NOW = datetime(2026, 9, 2, 12, 0, tzinfo=UTC)
+# An hour ago, not a literal date: `accept_duel` only allows a PENDING invite
+# whose `created_at` is inside `INVITE_TTL` (48h) of the real clock, so a
+# fixed calendar date rots the moment the suite runs more than 48h later.
+NOW = datetime.now(UTC) - timedelta(hours=1)
 
 
 def _duel(status=DuelStatus.PENDING, **overrides) -> Duel:
@@ -49,7 +52,10 @@ class _StubOperations:
         return self._players
 
     def accept(self, duel, now=None):
-        return _duel(status=DuelStatus.ACTIVE, starts_at=NOW, ends_at=NOW)
+        # A week-long window that just opened, not one that already ended --
+        # an `ends_at` in the past would make `get_duel` settle this duel on
+        # the spot the next time it is fetched.
+        return _duel(status=DuelStatus.ACTIVE, starts_at=NOW, ends_at=NOW + timedelta(days=7))
 
 
 @pytest.fixture

--- a/backend/community-backend/routes/community_models.py
+++ b/backend/community-backend/routes/community_models.py
@@ -34,6 +34,7 @@ class CommunityQuotedPostPreview(BaseModel):
     author_email: str | None = None
     author_first_name: str | None = None
     author_last_name: str | None = None
+    author_username: str | None = None
 
 
 class CommunityQuotedCommentPreview(BaseModel):
@@ -46,6 +47,7 @@ class CommunityQuotedCommentPreview(BaseModel):
     author_email: str | None = None
     author_first_name: str | None = None
     author_last_name: str | None = None
+    author_username: str | None = None
 
 
 class PostUpdate(BaseModel):
@@ -91,6 +93,7 @@ class CommunityPostResponse(BaseModel):
     author_email: str | None = None
     author_first_name: str | None = None
     author_last_name: str | None = None
+    author_username: str | None = None
     like_count: int = 0
     liked_by_current_user: bool = False
     repost_count: int = 0
@@ -156,6 +159,7 @@ class CommunityCommentResponse(BaseModel):
     author_email: str | None = None
     author_first_name: str | None = None
     author_last_name: str | None = None
+    author_username: str | None = None
     repost_count: int = 0
     reposted_by_current_user: bool = False
     media_urls: list[str] = Field(default_factory=list)

--- a/backend/community-backend/routes/community_models.py
+++ b/backend/community-backend/routes/community_models.py
@@ -137,12 +137,17 @@ class FollowResultResponse(BaseModel):
 
 
 class FollowUserResponse(BaseModel):
-    """One row in a followers or following list."""
+    """One row in a followers, following or follow-request list.
+
+    Raw name fields rather than a finished name, matching the community feed:
+    the client resolves the display ladder in `CommunityAuthorMapper`.
+    """
 
     user_id: str
     email: str | None = None
     first_name: str | None = None
     last_name: str | None = None
+    username: str | None = None
     created_at: str | None = None
 
 

--- a/backend/community-backend/services/community_comment_read_operations.py
+++ b/backend/community-backend/services/community_comment_read_operations.py
@@ -17,7 +17,9 @@ class CommunityCommentReadOperations:
         try:
             response = (
                 self._client.table("comments")
-                .select("*, user_info!comments_user_id_fkey(email, first_name, last_name)")
+                .select(
+                    "*, user_info!comments_user_id_fkey(email, first_name, last_name, username)"
+                )
                 .eq("id", comment_id)
                 .limit(1)
                 .execute()
@@ -110,7 +112,9 @@ class CommunityCommentReadOperations:
         try:
             response = (
                 self._client.table("comments")
-                .select("*, user_info!comments_user_id_fkey(email, first_name, last_name)")
+                .select(
+                    "*, user_info!comments_user_id_fkey(email, first_name, last_name, username)"
+                )
                 .eq("post_id", post_id)
                 .order("created_at", desc=False)
                 .execute()
@@ -159,7 +163,9 @@ class CommunityCommentReadOperations:
         try:
             response = (
                 self._client.table("comments")
-                .select("*, user_info!comments_user_id_fkey(email, first_name, last_name)")
+                .select(
+                    "*, user_info!comments_user_id_fkey(email, first_name, last_name, username)"
+                )
                 .in_("post_id", readable_ids)
                 .execute()
             )

--- a/backend/community-backend/services/community_post_read_operations.py
+++ b/backend/community-backend/services/community_post_read_operations.py
@@ -190,7 +190,7 @@ class CommunityPostReadOperations:
                     self._client.table("posts")
                     .select(
                         "post_id, user_id, title, content, created_at, "
-                        "user_info!posts_user_id_fkey(email, first_name, last_name)"
+                        "user_info!posts_user_id_fkey(email, first_name, last_name, username)"
                     )
                     .in_("post_id", unique_ids)
                     .or_(expression)
@@ -276,7 +276,7 @@ class CommunityPostReadOperations:
                     self._client.table("comments")
                     .select(
                         "id, user_id, post_id, content, created_at, "
-                        "user_info!comments_user_id_fkey(email, first_name, last_name)"
+                        "user_info!comments_user_id_fkey(email, first_name, last_name, username)"
                     )
                     .in_("id", unique_ids)
                     .execute()
@@ -318,7 +318,7 @@ class CommunityPostReadOperations:
             expression, _ = self._visible_posts(current_user_id)
             response = (
                 self._client.table("posts")
-                .select("*, user_info!posts_user_id_fkey(email, first_name, last_name)")
+                .select("*, user_info!posts_user_id_fkey(email, first_name, last_name, username)")
                 .eq("post_id", post_id)
                 .or_(expression)
                 .limit(1)
@@ -345,7 +345,7 @@ class CommunityPostReadOperations:
         try:
             response = (
                 self._client.table("posts")
-                .select("*, user_info!posts_user_id_fkey(email, first_name, last_name)")
+                .select("*, user_info!posts_user_id_fkey(email, first_name, last_name, username)")
                 .eq("subthread_id", subthread_id)
                 .or_(self._visible_posts(current_user_id)[0])
                 .order("created_at", desc=True)
@@ -375,7 +375,7 @@ class CommunityPostReadOperations:
         try:
             response = (
                 self._client.table("posts")
-                .select("*, user_info!posts_user_id_fkey(email, first_name, last_name)")
+                .select("*, user_info!posts_user_id_fkey(email, first_name, last_name, username)")
                 .eq("user_id", user_id)
                 .or_(self._visible_posts(current_user_id)[0])
                 .order("created_at", desc=True)
@@ -385,11 +385,7 @@ class CommunityPostReadOperations:
             response_data = getattr(response, "data", None)
             if isinstance(response_data, list):
                 for post in response_data:
-                    if "user_info" in post and post["user_info"]:
-                        author = post.pop("user_info")
-                        post["author_email"] = author.get("email")
-                        post["author_first_name"] = author.get("first_name")
-                        post["author_last_name"] = author.get("last_name")
+                    flatten_user_info(post)
                 return self._hydrate(response_data, current_user_id=current_user_id)
             return []
         except Exception as exception:
@@ -422,7 +418,7 @@ class CommunityPostReadOperations:
         try:
             response = (
                 self._client.table("posts")
-                .select("*, user_info!posts_user_id_fkey(email, first_name, last_name)")
+                .select("*, user_info!posts_user_id_fkey(email, first_name, last_name, username)")
                 .or_(self._visible_posts(current_user_id)[0])
                 .order("created_at", desc=True)
                 .range(offset, offset + limit - 1)
@@ -431,11 +427,7 @@ class CommunityPostReadOperations:
             response_data = getattr(response, "data", None)
             if isinstance(response_data, list):
                 for post in response_data:
-                    if "user_info" in post and post["user_info"]:
-                        author = post.pop("user_info")
-                        post["author_email"] = author.get("email")
-                        post["author_first_name"] = author.get("first_name")
-                        post["author_last_name"] = author.get("last_name")
+                    flatten_user_info(post)
                 return self._hydrate(response_data, current_user_id=current_user_id)
             return []
         except Exception as exception:

--- a/backend/community-backend/services/follow_operations.py
+++ b/backend/community-backend/services/follow_operations.py
@@ -217,7 +217,7 @@ class CommunityFollowOperations:
         try:
             response = (
                 self._client.table(FOLLOWS)
-                .select(f"{id_field}, created_at, {join}(email, first_name, last_name)")
+                .select(f"{id_field}, created_at, {join}(email, first_name, last_name, username)")
                 .eq(match_field, user_id)
                 .order("created_at", desc=True)
                 .range(offset, offset + limit - 1)
@@ -236,6 +236,7 @@ class CommunityFollowOperations:
                         "email": info.get("email"),
                         "first_name": info.get("first_name"),
                         "last_name": info.get("last_name"),
+                        "username": info.get("username"),
                         "created_at": row.get("created_at"),
                     }
                 )

--- a/backend/community-backend/services/follow_request_operations.py
+++ b/backend/community-backend/services/follow_request_operations.py
@@ -128,7 +128,7 @@ class CommunityFollowRequestOperations:
                 .select(
                     "requester_id, created_at, "
                     "user_info!follow_requests_requester_id_fkey"
-                    "(email, first_name, last_name)"
+                    "(email, first_name, last_name, username)"
                 )
                 .eq("target_id", target_id)
                 .order("created_at", desc=True)
@@ -148,6 +148,7 @@ class CommunityFollowRequestOperations:
                         "email": info.get("email"),
                         "first_name": info.get("first_name"),
                         "last_name": info.get("last_name"),
+                        "username": info.get("username"),
                         "created_at": row.get("created_at"),
                     }
                 )

--- a/backend/community-backend/services/mappers/community_row_mappers.py
+++ b/backend/community-backend/services/mappers/community_row_mappers.py
@@ -11,3 +11,4 @@ def flatten_user_info(row: dict[str, Any], field: str = "user_info") -> None:
     row["author_email"] = author.get("email")
     row["author_first_name"] = author.get("first_name")
     row["author_last_name"] = author.get("last_name")
+    row["author_username"] = author.get("username")

--- a/backend/community-backend/tests/test_operations_units.py
+++ b/backend/community-backend/tests/test_operations_units.py
@@ -868,3 +868,25 @@ def test_a_private_account_reads_its_own_profile(harness):
 def test_a_public_account_stays_open(harness):
     assert harness.can_read_account("user-1", "user-2") is True
     assert harness.can_read_account("user-1", None) is True
+
+
+def test_the_author_username_reaches_the_client():
+    # The feed resolves the display ladder in Dart, so the handle has to be
+    # on the row. Without it a user who set @snowking still shows as their
+    # real name in every post.
+    from services.mappers.community_row_mappers import flatten_user_info
+
+    row = {
+        "post_id": "p1",
+        "user_info": {
+            "email": "matthew@example.com",
+            "first_name": "Matthew",
+            "last_name": "Ng",
+            "username": "snowking",
+        },
+    }
+
+    flatten_user_info(row)
+
+    assert row["author_username"] == "snowking"
+    assert row["author_first_name"] == "Matthew"

--- a/backend/db/migrations/022_profiles_repair.sql
+++ b/backend/db/migrations/022_profiles_repair.sql
@@ -17,6 +17,10 @@
 
 begin;
 
+-- Deliberately strict: if this constraint is named something else, the
+-- transaction must abort. `if exists` would no-op and leave the old FK to
+-- auth.users in place beside the new one, and inserts would keep failing
+-- 23503 while the migration looked like it worked.
 alter table profiles drop constraint profiles_id_fkey;
 alter table profiles add constraint profiles_id_fkey
   foreign key (id) references user_info(id) on delete cascade;
@@ -30,7 +34,7 @@ select id from user_info
 on conflict (id) do nothing;
 
 -- The second source for a name, removed before anything can write to it.
-alter table profiles drop column full_name;
+alter table profiles drop column if exists full_name;
 
 -- The displayed identity moves to where every service already reads. Unique
 -- on lower(username) so SnowKing and snowking cannot both exist, and partial
@@ -39,6 +43,6 @@ alter table user_info add column if not exists username text;
 create unique index if not exists user_info_username_key
   on user_info (lower(username)) where username is not null;
 
-alter table profiles drop column username;
+alter table profiles drop column if exists username;
 
 commit;

--- a/backend/db/migrations/022_profiles_repair.sql
+++ b/backend/db/migrations/022_profiles_repair.sql
@@ -1,0 +1,44 @@
+-- Run this in the Supabase SQL editor after 021.
+--
+-- profiles.id references Supabase auth's `users`, but registration writes
+-- `user_info`, so every insert fails with 23503 and the table has never held
+-- a row: 41 users, 0 profiles. Every profile edit returns 500 and every
+-- uploaded avatar URL is discarded.
+--
+-- Repairing it as-is would be worse. profiles is read by one file;
+-- user_info is read by ten across three services, and every displayed name
+-- already comes from it. Keeping full_name creates a second source for one
+-- fact, and the profile screen and the feed would disagree silently.
+--
+-- One rule decides where a column lives: user_info holds what other services
+-- read, profiles holds what only the profile screen reads.
+--
+-- Design: docs/superpowers/specs/2026-09-04-profiles-repair-design.md
+
+begin;
+
+alter table profiles drop constraint profiles_id_fkey;
+alter table profiles add constraint profiles_id_fkey
+  foreign key (id) references user_info(id) on delete cascade;
+
+-- One profile per existing user. Ids only: usernames are chosen, never
+-- generated. Deriving them from email addresses would mint handles nobody
+-- picked, collide across domains, and leak the real names the field exists
+-- to hide.
+insert into profiles (id)
+select id from user_info
+on conflict (id) do nothing;
+
+-- The second source for a name, removed before anything can write to it.
+alter table profiles drop column full_name;
+
+-- The displayed identity moves to where every service already reads. Unique
+-- on lower(username) so SnowKing and snowking cannot both exist, and partial
+-- so the null usernames do not collide with each other.
+alter table user_info add column if not exists username text;
+create unique index if not exists user_info_username_key
+  on user_info (lower(username)) where username is not null;
+
+alter table profiles drop column username;
+
+commit;

--- a/backend/main-backend/app/api/v1/users_account_routes.py
+++ b/backend/main-backend/app/api/v1/users_account_routes.py
@@ -5,6 +5,7 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from app.api.dependencies import get_current_user
+from app.core.profile_cache import invalidate_profile
 from app.core.storage import User
 from app.core.supabase import supabase_client
 from app.schemas import UserResponse, UserUpdate
@@ -63,6 +64,10 @@ def update_current_user_profile(
         if user_update.last_name is not None:
             current_user.last_name = user_update.last_name
         logger.warning("Supabase not configured; user profile updated locally only")
+
+    # The profile response overlays its name from user_info, so a name
+    # written here has to drop the cached profile with it.
+    invalidate_profile(current_user.id)
 
     return UserResponse(
         id=current_user.id,

--- a/backend/main-backend/app/api/v1/users_avatar_routes.py
+++ b/backend/main-backend/app/api/v1/users_avatar_routes.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
 
 from app.api.dependencies import get_current_user
 from app.core.profile_cache import invalidate_profile
+from app.core.profile_identity import profile_with_identity
 from app.core.storage import User
 from app.core.supabase import supabase_client
 from app.schemas import ProfileResponse
@@ -53,6 +54,13 @@ async def upload_avatar(
         if existing_profile and existing_profile.get("avatar_url"):
             old_avatar_url = existing_profile["avatar_url"]
 
+        if existing_profile is None:
+            # A brand-new user has no `profiles` row until something creates
+            # one -- migration 022 does not backfill it. Same guard as
+            # update_current_user_profile_endpoint, so the update below has
+            # a row to match.
+            supabase_client.create_profile(user_id=current_user.id)
+
         new_avatar_url = supabase_client.upload_avatar(
             user_id=current_user.id,
             file_content=file_content,
@@ -72,14 +80,23 @@ async def upload_avatar(
             avatar_url=new_avatar_url,
         )
         if updated_profile is None:
+            # The row exists (just ensured above) but the write still
+            # failed. The upload already succeeded -- delete it rather than
+            # leave a storage object no profile points to; best-effort,
+            # since there is no retry machinery here to hand the cleanup to.
+            supabase_client.delete_avatar(current_user.id, new_avatar_url)
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Failed to update profile with new avatar",
             ) from None
 
+        # The write returns a bare `profiles` row, which no longer holds a
+        # name -- overlay it or the response blanks the user's name.
+        profile_data = profile_with_identity(current_user.id, updated_profile) or updated_profile
+
         invalidate_profile(current_user.id)
         logger.info(f"User {current_user.id} uploaded new avatar")
-        return ProfileResponse(**updated_profile)
+        return ProfileResponse(**profile_data)
 
     except HTTPException:
         raise

--- a/backend/main-backend/app/api/v1/users_profile_routes.py
+++ b/backend/main-backend/app/api/v1/users_profile_routes.py
@@ -1,14 +1,13 @@
 """Profile routes for authenticated and public user profile access."""
 
 import logging
-from datetime import UTC, datetime
-from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
 from app.api.dependencies import get_current_user
 from app.core.profile_cache import get_profile, invalidate_profile, set_profile
+from app.core.profile_identity import profile_with_identity
 from app.core.storage import User
 from app.core.supabase import supabase_client
 from app.schemas import ProfileResponse, ProfileUpdate, UsernameSetting
@@ -25,57 +24,6 @@ def _ensure_database_configured() -> None:
         ) from None
 
 
-def _profile_with_identity(
-    user_id: str,
-    profile: dict[str, Any] | None,
-) -> dict[str, Any] | None:
-    """Merge a `profiles` row with the identity fields `user_info` owns.
-
-    The overlay is unconditional, not a not-found fallback. Migration 022
-    dropped `profiles.full_name` and moved `username` to `user_info`;
-    `country_code` moved there in 021. A `profiles` row therefore carries
-    none of the three, so a response built from that row alone would show no
-    name at all -- which is exactly what applying 022 would do to the 41
-    users it gives a row to.
-
-    `profile` may be None. `user_info` is always present for a live user --
-    it is what `posts.user_id` and `activities.user_id` reference -- so it is
-    enough to render a profile from on its own. Nothing is written here.
-
-    Args:
-        user_id: The user being rendered.
-        profile: Their `profiles` row, or None if they have none yet.
-
-    Returns:
-        A full profile payload, or None when neither table has the user.
-    """
-    user = supabase_client.get_user_info_by_id(user_id)
-    if user is None and profile is None:
-        return None
-
-    user = user or {}
-    row = profile or {}
-    first = (user.get("first_name") or "").strip()
-    last = (user.get("last_name") or "").strip()
-
-    return {
-        "id": user_id,
-        # Presentation: profiles owns these.
-        "bio": row.get("bio"),
-        "avatar_url": row.get("avatar_url"),
-        "push_token": row.get("push_token"),
-        "ski_level": row.get("ski_level"),
-        "home": row.get("home"),
-        # Identity: user_info owns these, since migrations 021 and 022.
-        "full_name": " ".join(p for p in (first, last) if p) or None,
-        "username": user.get("username"),
-        "country_code": user.get("country_code"),
-        # user_info.created_at is nullable even though it defaults to now().
-        "created_at": row.get("created_at") or user.get("created_at") or datetime.now(UTC),
-        "updated_at": row.get("updated_at") or user.get("updated_at"),
-    }
-
-
 @router.get("/me/profile", response_model=ProfileResponse)
 def get_current_user_profile_endpoint(
     current_user: User = Depends(get_current_user),
@@ -90,7 +38,7 @@ def get_current_user_profile_endpoint(
                 row = supabase_client.create_profile(user_id=current_user.id)
             # Overlaid before caching: a row cached without its identity
             # fields would serve a nameless profile for the whole TTL.
-            profile_data = _profile_with_identity(current_user.id, row)
+            profile_data = profile_with_identity(current_user.id, row)
             if profile_data is None:
                 raise HTTPException(
                     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -180,7 +128,7 @@ def update_current_user_profile_endpoint(
 
         # The write returns a bare `profiles` row, which no longer holds a
         # name -- overlay it or the save reads back blank.
-        profile_data = _profile_with_identity(current_user.id, updated_profile) or updated_profile
+        profile_data = profile_with_identity(current_user.id, updated_profile) or updated_profile
 
         invalidate_profile(current_user.id)
         logger.info(f"User {current_user.id} profile updated")
@@ -282,7 +230,7 @@ def get_user_profile_by_id(
         profile_data = get_profile(user_id)
         if profile_data is None:
             # Overlaid before caching, for the same reason as /me/profile.
-            profile_data = _profile_with_identity(
+            profile_data = profile_with_identity(
                 user_id, supabase_client.get_profile_by_id(user_id)
             )
             if profile_data is None:

--- a/backend/main-backend/app/api/v1/users_profile_routes.py
+++ b/backend/main-backend/app/api/v1/users_profile_routes.py
@@ -11,7 +11,7 @@ from app.api.dependencies import get_current_user
 from app.core.profile_cache import get_profile, invalidate_profile, set_profile
 from app.core.storage import User
 from app.core.supabase import supabase_client
-from app.schemas import ProfileResponse, ProfileUpdate
+from app.schemas import ProfileResponse, ProfileUpdate, UsernameSetting
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -42,12 +42,11 @@ def _profile_from_user_info(user_id: str) -> dict[str, Any] | None:
 
     first = (user.get("first_name") or "").strip()
     last = (user.get("last_name") or "").strip()
-    email = (user.get("email") or "").strip()
 
     return {
         "id": user_id,
         "full_name": " ".join(p for p in (first, last) if p) or None,
-        "username": email.split("@")[0] if "@" in email else None,
+        "username": user.get("username"),
         "bio": None,
         "avatar_url": None,
         "push_token": None,
@@ -150,28 +149,20 @@ def update_current_user_profile_endpoint(
     profile_update: ProfileUpdate,
     current_user: User = Depends(get_current_user),
 ) -> ProfileResponse:
-    """Update current user's profile details."""
+    """Update current user's profile details.
+
+    `full_name` and `username` are not settable here -- both moved to
+    `user_info` in migration 022. Use PUT /me/username for the handle; the
+    full name is derived from `user_info.first_name`/`last_name`.
+    """
     _ensure_database_configured()
     try:
-        if profile_update.username is not None:
-            is_username_taken = supabase_client.username_exists(
-                profile_update.username,
-                exclude_user_id=current_user.id,
-            )
-            if is_username_taken:
-                raise HTTPException(
-                    status_code=status.HTTP_409_CONFLICT,
-                    detail="Username already taken",
-                ) from None
-
         existing_profile = supabase_client.get_profile_by_id(current_user.id)
         if existing_profile is None:
             supabase_client.create_profile(user_id=current_user.id)
 
         updated_profile = supabase_client.update_profile(
             user_id=current_user.id,
-            full_name=profile_update.full_name,
-            username=profile_update.username,
             bio=profile_update.bio,
             avatar_url=profile_update.avatar_url,
             push_token=profile_update.push_token,
@@ -233,6 +224,44 @@ def set_my_country(
 
     invalidate_profile(current_user.id)
     return setting
+
+
+@router.put("/me/username", response_model=UsernameSetting)
+def set_my_username(
+    setting: UsernameSetting,
+    current_user: User = Depends(get_current_user),
+) -> UsernameSetting:
+    """Choose the handle this account is known by.
+
+    Its own route rather than a field on PUT /me/profile, for the same
+    reason /me/privacy and /me/country are: those write `user_info`, and
+    that is where a name has to live for a feed to read it.
+
+    Stored lower-cased so `@snowking` has one spelling. Null clears it and
+    the display falls back to the user's name.
+
+    Raises:
+        HTTPException: 409 if another account already has the handle, 404 if
+            the user is gone.
+    """
+    _ensure_database_configured()
+
+    handle = setting.username.lower() if setting.username else None
+
+    if handle and supabase_client.username_exists(handle, exclude_user_id=current_user.id):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="That username is taken",
+        ) from None
+
+    if not supabase_client.set_username(current_user.id, handle):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found",
+        ) from None
+
+    invalidate_profile(current_user.id)
+    return UsernameSetting(username=handle)
 
 
 @router.get("/{user_id}/profile", response_model=ProfileResponse)

--- a/backend/main-backend/app/api/v1/users_profile_routes.py
+++ b/backend/main-backend/app/api/v1/users_profile_routes.py
@@ -25,39 +25,54 @@ def _ensure_database_configured() -> None:
         ) from None
 
 
-def _profile_from_user_info(user_id: str) -> dict[str, Any] | None:
-    """Build a profile for a user who has no row in `profiles`.
+def _profile_with_identity(
+    user_id: str,
+    profile: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Merge a `profiles` row with the identity fields `user_info` owns.
 
-    Most users have none. `profiles.id` carries a foreign key to Supabase
-    auth's `users` table, but registration writes to `user_info`, so every
-    insert in `create_profile` fails with 23503 and the row is never made.
+    The overlay is unconditional, not a not-found fallback. Migration 022
+    dropped `profiles.full_name` and moved `username` to `user_info`;
+    `country_code` moved there in 021. A `profiles` row therefore carries
+    none of the three, so a response built from that row alone would show no
+    name at all -- which is exactly what applying 022 would do to the 41
+    users it gives a row to.
 
-    `user_info` is always present -- it is what `posts.user_id` and
-    `activities.user_id` reference -- so it is enough to render a profile
-    from. Nothing is written: this is a read-time fallback, not a repair.
+    `profile` may be None. `user_info` is always present for a live user --
+    it is what `posts.user_id` and `activities.user_id` reference -- so it is
+    enough to render a profile from on its own. Nothing is written here.
+
+    Args:
+        user_id: The user being rendered.
+        profile: Their `profiles` row, or None if they have none yet.
+
+    Returns:
+        A full profile payload, or None when neither table has the user.
     """
     user = supabase_client.get_user_info_by_id(user_id)
-    if user is None:
+    if user is None and profile is None:
         return None
 
+    user = user or {}
+    row = profile or {}
     first = (user.get("first_name") or "").strip()
     last = (user.get("last_name") or "").strip()
 
     return {
         "id": user_id,
+        # Presentation: profiles owns these.
+        "bio": row.get("bio"),
+        "avatar_url": row.get("avatar_url"),
+        "push_token": row.get("push_token"),
+        "ski_level": row.get("ski_level"),
+        "home": row.get("home"),
+        # Identity: user_info owns these, since migrations 021 and 022.
         "full_name": " ".join(p for p in (first, last) if p) or None,
         "username": user.get("username"),
-        "bio": None,
-        "avatar_url": None,
-        "push_token": None,
-        "ski_level": None,
-        "home": None,
-        # The one field on this fallback that is real: it lives on user_info,
-        # written by PUT /me/country. See migration 021.
         "country_code": user.get("country_code"),
         # user_info.created_at is nullable even though it defaults to now().
-        "created_at": user.get("created_at") or datetime.now(UTC),
-        "updated_at": user.get("updated_at"),
+        "created_at": row.get("created_at") or user.get("created_at") or datetime.now(UTC),
+        "updated_at": row.get("updated_at") or user.get("updated_at"),
     }
 
 
@@ -70,11 +85,12 @@ def get_current_user_profile_endpoint(
     try:
         profile_data = get_profile(current_user.id)
         if profile_data is None:
-            profile_data = supabase_client.get_profile_by_id(current_user.id)
-            if profile_data is None:
-                profile_data = supabase_client.create_profile(user_id=current_user.id)
-            if profile_data is None:
-                profile_data = _profile_from_user_info(current_user.id)
+            row = supabase_client.get_profile_by_id(current_user.id)
+            if row is None:
+                row = supabase_client.create_profile(user_id=current_user.id)
+            # Overlaid before caching: a row cached without its identity
+            # fields would serve a nameless profile for the whole TTL.
+            profile_data = _profile_with_identity(current_user.id, row)
             if profile_data is None:
                 raise HTTPException(
                     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -162,9 +178,13 @@ def update_current_user_profile_endpoint(
                 detail="Failed to update profile",
             ) from None
 
+        # The write returns a bare `profiles` row, which no longer holds a
+        # name -- overlay it or the save reads back blank.
+        profile_data = _profile_with_identity(current_user.id, updated_profile) or updated_profile
+
         invalidate_profile(current_user.id)
         logger.info(f"User {current_user.id} profile updated")
-        return ProfileResponse(**updated_profile)
+        return ProfileResponse(**profile_data)
     except HTTPException:
         raise
     except Exception as exception:
@@ -261,9 +281,10 @@ def get_user_profile_by_id(
     try:
         profile_data = get_profile(user_id)
         if profile_data is None:
-            profile_data = supabase_client.get_profile_by_id(user_id)
-            if profile_data is None:
-                profile_data = _profile_from_user_info(user_id)
+            # Overlaid before caching, for the same reason as /me/profile.
+            profile_data = _profile_with_identity(
+                user_id, supabase_client.get_profile_by_id(user_id)
+            )
             if profile_data is None:
                 raise HTTPException(
                     status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/main-backend/app/api/v1/users_profile_routes.py
+++ b/backend/main-backend/app/api/v1/users_profile_routes.py
@@ -61,16 +61,6 @@ def _profile_from_user_info(user_id: str) -> dict[str, Any] | None:
     }
 
 
-def _build_default_full_name(current_user: User) -> str | None:
-    if current_user.first_name and current_user.last_name:
-        return f"{current_user.first_name} {current_user.last_name}"
-    if current_user.first_name:
-        return current_user.first_name
-    if current_user.last_name:
-        return current_user.last_name
-    return None
-
-
 @router.get("/me/profile", response_model=ProfileResponse)
 def get_current_user_profile_endpoint(
     current_user: User = Depends(get_current_user),
@@ -82,10 +72,7 @@ def get_current_user_profile_endpoint(
         if profile_data is None:
             profile_data = supabase_client.get_profile_by_id(current_user.id)
             if profile_data is None:
-                profile_data = supabase_client.create_profile(
-                    user_id=current_user.id,
-                    full_name=_build_default_full_name(current_user),
-                )
+                profile_data = supabase_client.create_profile(user_id=current_user.id)
             if profile_data is None:
                 profile_data = _profile_from_user_info(current_user.id)
             if profile_data is None:

--- a/backend/main-backend/app/core/profile_identity.py
+++ b/backend/main-backend/app/core/profile_identity.py
@@ -1,0 +1,67 @@
+"""Overlay `user_info` identity fields onto a `profiles` row.
+
+Shared by every route that returns a `ProfileResponse` --
+`users_profile_routes.py` and `users_avatar_routes.py` -- so it lives here,
+in `core`, rather than in either route module. A route module importing a
+helper out of a sibling route module is a layering smell even where it
+happens not to cycle; `core` is where both already look for shared logic
+(see `profile_cache.py` next door).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from app.core.supabase import supabase_client
+
+
+def profile_with_identity(
+    user_id: str,
+    profile: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Merge a `profiles` row with the identity fields `user_info` owns.
+
+    The overlay is unconditional, not a not-found fallback. Migration 022
+    dropped `profiles.full_name` and moved `username` to `user_info`;
+    `country_code` moved there in 021. A `profiles` row therefore carries
+    none of the three, so a response built from that row alone would show no
+    name at all -- which is exactly what applying 022 would do to the 41
+    users it gives a row to.
+
+    `profile` may be None. `user_info` is always present for a live user --
+    it is what `posts.user_id` and `activities.user_id` reference -- so it is
+    enough to render a profile from on its own. Nothing is written here.
+
+    Args:
+        user_id: The user being rendered.
+        profile: Their `profiles` row, or None if they have none yet.
+
+    Returns:
+        A full profile payload, or None when neither table has the user.
+    """
+    user = supabase_client.get_user_info_by_id(user_id)
+    if user is None and profile is None:
+        return None
+
+    user = user or {}
+    row = profile or {}
+    first = (user.get("first_name") or "").strip()
+    last = (user.get("last_name") or "").strip()
+
+    return {
+        "id": user_id,
+        # Presentation: profiles owns these.
+        "bio": row.get("bio"),
+        "avatar_url": row.get("avatar_url"),
+        "push_token": row.get("push_token"),
+        "ski_level": row.get("ski_level"),
+        "home": row.get("home"),
+        # Identity: user_info owns these, since migrations 021 and 022.
+        "full_name": " ".join(p for p in (first, last) if p) or None,
+        "username": user.get("username"),
+        "country_code": user.get("country_code"),
+        # user_info.created_at is nullable even though it defaults to now().
+        "created_at": row.get("created_at") or user.get("created_at") or datetime.now(UTC),
+        "updated_at": row.get("updated_at") or user.get("updated_at"),
+    }

--- a/backend/main-backend/app/core/supabase/comments.py
+++ b/backend/main-backend/app/core/supabase/comments.py
@@ -75,7 +75,9 @@ class CommentOperations(SupabaseBase):
         try:
             resp = (
                 client.table("comments")
-                .select("*, user_info!comments_user_id_fkey(email, first_name, last_name)")
+                .select(
+                    "*, user_info!comments_user_id_fkey(email, first_name, last_name, username)"
+                )
                 .eq("id", comment_id)
                 .limit(1)
                 .execute()
@@ -89,6 +91,7 @@ class CommentOperations(SupabaseBase):
                     comment["author_email"] = author.get("email")
                     comment["author_first_name"] = author.get("first_name")
                     comment["author_last_name"] = author.get("last_name")
+                    comment["author_username"] = author.get("username")
                 return comment
             return None
         except Exception as exc:
@@ -108,7 +111,9 @@ class CommentOperations(SupabaseBase):
         try:
             resp = (
                 client.table("comments")
-                .select("*, user_info!comments_user_id_fkey(email, first_name, last_name)")
+                .select(
+                    "*, user_info!comments_user_id_fkey(email, first_name, last_name, username)"
+                )
                 .eq("post_id", post_id)
                 .order("created_at", desc=False)
                 .execute()
@@ -122,6 +127,7 @@ class CommentOperations(SupabaseBase):
                         comment["author_email"] = author.get("email")
                         comment["author_first_name"] = author.get("first_name")
                         comment["author_last_name"] = author.get("last_name")
+                        comment["author_username"] = author.get("username")
                 return data
             return []
         except Exception as exc:

--- a/backend/main-backend/app/core/supabase/posts.py
+++ b/backend/main-backend/app/core/supabase/posts.py
@@ -74,7 +74,7 @@ class PostOperations(SupabaseBase):
         try:
             resp = (
                 client.table("posts")
-                .select("*, user_info!posts_user_id_fkey(email, first_name, last_name)")
+                .select("*, user_info!posts_user_id_fkey(email, first_name, last_name, username)")
                 .eq("post_id", post_id)
                 .limit(1)
                 .execute()
@@ -88,6 +88,7 @@ class PostOperations(SupabaseBase):
                     post["author_email"] = author.get("email")
                     post["author_first_name"] = author.get("first_name")
                     post["author_last_name"] = author.get("last_name")
+                    post["author_username"] = author.get("username")
                 return post
             return None
         except Exception as exc:
@@ -112,7 +113,7 @@ class PostOperations(SupabaseBase):
         try:
             resp = (
                 client.table("posts")
-                .select("*, user_info!posts_user_id_fkey(email, first_name, last_name)")
+                .select("*, user_info!posts_user_id_fkey(email, first_name, last_name, username)")
                 .eq("subthread_id", subthread_id)
                 .order("created_at", desc=True)
                 .range(offset, offset + limit - 1)
@@ -127,6 +128,7 @@ class PostOperations(SupabaseBase):
                         post["author_email"] = author.get("email")
                         post["author_first_name"] = author.get("first_name")
                         post["author_last_name"] = author.get("last_name")
+                        post["author_username"] = author.get("username")
                 return data
             return []
         except Exception as exc:
@@ -173,7 +175,7 @@ class PostOperations(SupabaseBase):
         try:
             resp = (
                 client.table("posts")
-                .select("*, user_info!posts_user_id_fkey(email, first_name, last_name)")
+                .select("*, user_info!posts_user_id_fkey(email, first_name, last_name, username)")
                 .eq("user_id", user_id)
                 .order("created_at", desc=True)
                 .range(offset, offset + limit - 1)
@@ -188,6 +190,7 @@ class PostOperations(SupabaseBase):
                         post["author_email"] = author.get("email")
                         post["author_first_name"] = author.get("first_name")
                         post["author_last_name"] = author.get("last_name")
+                        post["author_username"] = author.get("username")
                 return data
             return []
         except Exception as exc:

--- a/backend/main-backend/app/core/supabase/profiles.py
+++ b/backend/main-backend/app/core/supabase/profiles.py
@@ -16,7 +16,7 @@ class ProfileOperations(SupabaseBase):
     Profile table operations.
 
     Handles CRUD operations for the profiles table (Create, Read, Update, Delete):
-    - id (uuid, primary key, foreign key to auth.users)
+    - id (uuid, primary key, foreign key to user_info.id -- see migration 022)
     - bio (text, nullable)
     - avatar_url (text, nullable)
     - push_token (text, nullable): push notification token for backend to send notifications to the user
@@ -25,8 +25,15 @@ class ProfileOperations(SupabaseBase):
     - created_at (timestamptz, default now())
     - updated_at (timestamptz, default now(), updated via trigger)
 
-    The id serves as both primary key and foreign key reference to auth.users.
+    The id serves as both primary key and foreign key reference to user_info.
+    It pointed at Supabase auth's `users` until migration 022, which is why
+    every insert failed with 23503 and the table held no rows.
+
     The one-to-one relationship ensures each authenticated user has exactly one profile.
+
+    `full_name` and `username` are not columns here: 022 dropped the first
+    and moved the second to `user_info`, where every service already reads
+    names. A profile response overlays both from there.
     """
 
     def get_profile_by_id(self, user_id: str) -> dict[str, Any] | None:
@@ -39,7 +46,7 @@ class ProfileOperations(SupabaseBase):
         Expected Return:
         - Optional[Dict[str, Any]]: the profile data for the user, or None if not found
 
-        - e.g. [{'id': '123', 'full_name': 'John Doe', 'username': 'johndoe', 'bio': 'I am a software engineer', 'avatar_url': 'https://example.com/avatar.jpg', 'push_token': '1234567890', 'ski_level': 'beginner', 'home': 'New York', 'created_at': '2021-01-01 12:00:00', 'updated_at': '2021-01-01 12:00:00'}]
+        - e.g. [{'id': '123', 'bio': 'I am a software engineer', 'avatar_url': 'https://example.com/avatar.jpg', 'push_token': '1234567890', 'ski_level': 'beginner', 'home': 'New York', 'created_at': '2021-01-01 12:00:00', 'updated_at': '2021-01-01 12:00:00'}]
         """
 
         if not self.is_configured():
@@ -168,7 +175,7 @@ class ProfileOperations(SupabaseBase):
 
         Expected Return:
         - Optional[Dict[str, Any]]: the profile data for the user, or None if not found
-        - e.g. [{'id': '123', 'full_name': 'John Doe', 'username': 'johndoe', 'bio': 'I am a software engineer', 'avatar_url': 'https://example.com/avatar.jpg', 'push_token': '1234567890', 'ski_level': 'beginner', 'home': 'New York', 'created_at': '2021-01-01 12:00:00', 'updated_at': '2021-01-01 12:00:00'}]
+        - e.g. [{'id': '123', 'bio': 'I am a software engineer', 'avatar_url': 'https://example.com/avatar.jpg', 'push_token': '1234567890', 'ski_level': 'beginner', 'home': 'New York', 'created_at': '2021-01-01 12:00:00', 'updated_at': '2021-01-01 12:00:00'}]
         """
         if not self.is_configured():
             logger.warning("Supabase not configured; skipping update_profile.")

--- a/backend/main-backend/app/core/supabase/profiles.py
+++ b/backend/main-backend/app/core/supabase/profiles.py
@@ -17,8 +17,6 @@ class ProfileOperations(SupabaseBase):
 
     Handles CRUD operations for the profiles table (Create, Read, Update, Delete):
     - id (uuid, primary key, foreign key to auth.users)
-    - full_name (text, nullable)
-    - username (text, unique, nullable)
     - bio (text, nullable)
     - avatar_url (text, nullable)
     - push_token (text, nullable): push notification token for backend to send notifications to the user
@@ -79,8 +77,6 @@ class ProfileOperations(SupabaseBase):
         self,
         user_id: str,
         *,
-        full_name: str | None = None,
-        username: str | None = None,
         bio: str | None = None,
         avatar_url: str | None = None,
         push_token: str | None = None,
@@ -95,8 +91,6 @@ class ProfileOperations(SupabaseBase):
 
         Arguments:
         - user_id: str, the id of the user to create the profile for
-        - full_name: Optional[str], the full name of the user
-        - username: Optional[str], the username of the user
         - bio: Optional[str], the bio of the user
         - avatar_url: Optional[str], the avatar url of the user
         - push_token: Optional[str], the push token of the user
@@ -105,7 +99,7 @@ class ProfileOperations(SupabaseBase):
 
         Expected Return:
         - Optional[Dict[str, Any]]: the profile data for the user, or None if not found
-        - e.g. [{'id': '123', 'full_name': 'John Doe', 'username': 'johndoe', 'bio': 'I am a software engineer', 'avatar_url': 'https://example.com/avatar.jpg', 'push_token': '1234567890', 'ski_level': 'beginner', 'home': 'New York', 'created_at': '2021-01-01 12:00:00', 'updated_at': '2021-01-01 12:00:00'}]
+        - e.g. [{'id': '123', 'bio': 'I am a software engineer', 'avatar_url': 'https://example.com/avatar.jpg', 'push_token': '1234567890', 'ski_level': 'beginner', 'home': 'New York', 'created_at': '2021-01-01 12:00:00', 'updated_at': '2021-01-01 12:00:00'}]
         """
         if not self.is_configured():
             logger.warning("Supabase not configured; skipping create_profile.")
@@ -120,10 +114,6 @@ class ProfileOperations(SupabaseBase):
             payload: dict[str, Any] = {
                 "id": user_id,
             }
-            if full_name is not None:
-                payload["full_name"] = full_name
-            if username is not None:
-                payload["username"] = username
             if bio is not None:
                 payload["bio"] = bio
             if avatar_url is not None:

--- a/backend/main-backend/app/core/supabase/profiles.py
+++ b/backend/main-backend/app/core/supabase/profiles.py
@@ -152,8 +152,6 @@ class ProfileOperations(SupabaseBase):
         self,
         user_id: str,
         *,
-        full_name: str | None = None,
-        username: str | None = None,
         bio: str | None = None,
         avatar_url: str | None = None,
         push_token: str | None = None,
@@ -166,10 +164,12 @@ class ProfileOperations(SupabaseBase):
         Only updates provided fields (partial update).
         Returns updated profile dict on success, or None on failure.
 
+        `full_name` and `username` are not here: both moved to `user_info` in
+        migration 022, and `set_username` on `UserOperations` is how a
+        handle is written now.
+
         Arguments:
         - user_id: str, the id of the user to update the profile for
-        - full_name: Optional[str], the full name of the user
-        - username: Optional[str], the username of the user
         - bio: Optional[str], the bio of the user
         - avatar_url: Optional[str], the avatar url of the user
         - push_token: Optional[str], the push token of the user
@@ -190,10 +190,6 @@ class ProfileOperations(SupabaseBase):
 
         # Build update payload with only provided fields
         update_data: dict[str, Any] = {}
-        if full_name is not None:
-            update_data["full_name"] = full_name
-        if username is not None:
-            update_data["username"] = username
         if bio is not None:
             update_data["bio"] = bio
         if avatar_url is not None:
@@ -222,38 +218,6 @@ class ProfileOperations(SupabaseBase):
         except Exception as exc:
             logger.exception(f"Failed to update profile for user {user_id}: {exc}")
             return None
-
-    def username_exists(self, username: str, exclude_user_id: str | None = None) -> bool:
-        """
-        Check if username already exists (excluding a specific user if provided).
-
-        Arguments:
-        - username: str, the username to check if it exists
-        - exclude_user_id: Optional[str], the id of the user to exclude from the check
-
-        Expected Return:
-        - bool: True if the username exists, False if it does not
-        """
-        if not self.is_configured():
-            return False
-
-        client = self._client
-        if client is None:
-            return False
-
-        try:
-            query = client.table("profiles").select("id").eq("username", username)
-            if exclude_user_id:
-                query = query.neq("id", exclude_user_id)
-                # neq = not equal to, exclude the user_id from the check
-            # `resp` = response from the database query
-            resp = query.limit(1).execute()
-            # `data` = data returned from the database query
-            data = getattr(resp, "data", None)
-            return isinstance(data, list) and len(data) > 0
-        except Exception as exc:
-            logger.exception(f"Error checking username existence: {exc}")
-            return False
 
     def upload_avatar(
         self,

--- a/backend/main-backend/app/core/supabase/users.py
+++ b/backend/main-backend/app/core/supabase/users.py
@@ -197,6 +197,61 @@ class UserOperations(SupabaseBase):
             logger.exception(f"Failed to set country_code for user {id}: {exc}")
             return False
 
+    def username_exists(self, username: str, exclude_user_id: str | None = None) -> bool:
+        """Whether a handle is already taken, case-insensitively.
+
+        Lives here, not on profiles: `username` moved to `user_info` in
+        migration 022 because every service reads names from there.
+
+        Args:
+            username: The handle to check.
+            exclude_user_id: A user to ignore, so re-submitting your own
+                handle is not a conflict with yourself.
+
+        Returns:
+            True when taken. True on a failed read as well -- refusing a
+            free handle is recoverable, handing out a duplicate is not.
+        """
+        if not self.is_configured():
+            return False
+        client = self._client
+        if client is None:
+            return False
+        try:
+            query = client.table("user_info").select("id").ilike("username", username)
+            if exclude_user_id:
+                query = query.neq("id", exclude_user_id)
+            resp = query.limit(1).execute()
+            data = getattr(resp, "data", None)
+            return isinstance(data, list) and len(data) > 0
+        except Exception as exc:
+            logger.exception(f"Error checking username existence: {exc}")
+            return True
+
+    def set_username(self, id: str, username: str | None) -> bool:
+        """Set or clear the handle this account is known by.
+
+        Args:
+            id: The user.
+            username: The handle, already lower-cased and validated, or None
+                to clear it.
+
+        Returns:
+            True when a row was updated.
+        """
+        if not self.is_configured():
+            logger.warning("Supabase not configured; skipping set_username.")
+            return False
+        client = self._client
+        if client is None:
+            return False
+        try:
+            resp = client.table("user_info").update({"username": username}).eq("id", id).execute()
+            return bool(getattr(resp, "data", None))
+        except Exception as exc:
+            logger.exception(f"Failed to set username for user {id}: {exc}")
+            return False
+
     def email_exists(self, email: str) -> bool:
         """Check if email already exists in user_info table."""
         if not self.is_configured():

--- a/backend/main-backend/app/core/supabase/users.py
+++ b/backend/main-backend/app/core/supabase/users.py
@@ -106,10 +106,14 @@ class UserOperations(SupabaseBase):
             return None
         try:
             normalized_email = email.strip().lower()
+            # eq, not ilike: addresses are stored lower-cased, so an exact match is
+            # already case-insensitive, and ilike would read `%` and `_` -- both legal
+            # in a local part -- as wildcards on an attacker-supplied login address.
             resp = (
                 client.table("user_info")
                 .select("*")
-                .ilike("email", normalized_email)
+                .eq("email", normalized_email)
+                .order("id")
                 .limit(1)
                 .execute()
             )

--- a/backend/main-backend/app/core/supabase/users.py
+++ b/backend/main-backend/app/core/supabase/users.py
@@ -218,7 +218,9 @@ class UserOperations(SupabaseBase):
         if client is None:
             return False
         try:
-            query = client.table("user_info").select("id").ilike("username", username)
+            # eq, not ilike: the route lowercases before writing, so an exact match is
+            # already case-insensitive, and ilike would read `_` in a handle as a wildcard.
+            query = client.table("user_info").select("id").eq("username", username)
             if exclude_user_id:
                 query = query.neq("id", exclude_user_id)
             resp = query.limit(1).execute()

--- a/backend/main-backend/app/schemas/__init__.py
+++ b/backend/main-backend/app/schemas/__init__.py
@@ -69,10 +69,13 @@ class UserResponse(BaseModel):
 
 
 class ProfileBase(BaseModel):
-    """Shared profile properties."""
+    """Shared profile properties.
 
-    full_name: str | None = None
-    username: str | None = None
+    No `full_name` or `username`: migration 022 dropped the first and moved
+    the second to `user_info`. Both are read back on a profile response, but
+    neither is a profile property to declare here.
+    """
+
     bio: str | None = None
     avatar_url: str | None = None
     push_token: str | None = None

--- a/backend/main-backend/app/schemas/__init__.py
+++ b/backend/main-backend/app/schemas/__init__.py
@@ -83,13 +83,27 @@ class ProfileBase(BaseModel):
 class ProfileUpdate(BaseModel):
     """Schema for profile updates."""
 
-    full_name: str | None = None
-    username: str | None = None
     bio: str | None = None
     avatar_url: str | None = None
     push_token: str | None = None
     ski_level: str | None = None
     home: str | None = None
+
+
+class UsernameSetting(BaseModel):
+    """The handle this account is known by.
+
+    Lower case only, so `@snowking` has exactly one spelling and the mention
+    parser has one thing to match. Null clears it; the display falls back to
+    the user's name.
+    """
+
+    username: str | None = Field(
+        None,
+        min_length=3,
+        max_length=20,
+        pattern=r"^[a-zA-Z0-9_]+$",
+    )
 
 
 class ProfileResponse(BaseModel):

--- a/backend/main-backend/tests/conftest.py
+++ b/backend/main-backend/tests/conftest.py
@@ -61,7 +61,16 @@ class _StubSupabase:
         return True
 
     def username_exists(self, username: str, exclude_user_id: str | None = None) -> bool:
-        return username in self.taken_usernames
+        if username in self.taken_usernames:
+            return True
+        # Also honour a handle already sitting on some other user's row, so
+        # an implementation that dropped exclude_user_id would fail a test
+        # that resubmits the current user's own handle.
+        return any(
+            row.get("username") == username
+            for uid, row in self.user_info.items()
+            if uid != exclude_user_id
+        )
 
     def set_username(self, id: str, username: str | None) -> bool:
         row = self.user_info.get(id)
@@ -87,8 +96,10 @@ def stub_supabase(monkeypatch, app):
     monkeypatch.setattr(supabase_client, "set_username", stub.set_username)
 
     def _current_user() -> User:
-        # is_private lives on the raw user_info row, not on the User model.
-        row = {k: v for k, v in stub.user_info["user-1"].items() if k != "is_private"}
+        # is_private and username live on the raw user_info row, not on the
+        # User model.
+        excluded = {"is_private", "username"}
+        row = {k: v for k, v in stub.user_info["user-1"].items() if k not in excluded}
         return User(**row)  # type: ignore[arg-type]
 
     app.dependency_overrides[get_current_user] = _current_user

--- a/backend/main-backend/tests/conftest.py
+++ b/backend/main-backend/tests/conftest.py
@@ -45,6 +45,7 @@ class _StubSupabase:
                 "is_private": False,
             }
         }
+        self.taken_usernames: set[str] = set()
 
     def is_configured(self) -> bool:
         return True
@@ -57,6 +58,16 @@ class _StubSupabase:
         if row is None:
             return False
         row["is_private"] = is_private
+        return True
+
+    def username_exists(self, username: str, exclude_user_id: str | None = None) -> bool:
+        return username in self.taken_usernames
+
+    def set_username(self, id: str, username: str | None) -> bool:
+        row = self.user_info.get(id)
+        if row is None:
+            return False
+        row["username"] = username
         return True
 
 
@@ -72,6 +83,8 @@ def stub_supabase(monkeypatch, app):
     monkeypatch.setattr(supabase_client, "is_configured", stub.is_configured)
     monkeypatch.setattr(supabase_client, "get_user_info_by_id", stub.get_user_info_by_id)
     monkeypatch.setattr(supabase_client, "set_user_privacy", stub.set_user_privacy)
+    monkeypatch.setattr(supabase_client, "username_exists", stub.username_exists)
+    monkeypatch.setattr(supabase_client, "set_username", stub.set_username)
 
     def _current_user() -> User:
         # is_private lives on the raw user_info row, not on the User model.

--- a/backend/main-backend/tests/conftest.py
+++ b/backend/main-backend/tests/conftest.py
@@ -96,9 +96,8 @@ def stub_supabase(monkeypatch, app):
     monkeypatch.setattr(supabase_client, "set_username", stub.set_username)
 
     def _current_user() -> User:
-        # is_private and username live on the raw user_info row, not on the
-        # User model.
-        excluded = {"is_private", "username"}
+        # These live on the raw user_info row, not on the User model.
+        excluded = {"is_private", "username", "country_code"}
         row = {k: v for k, v in stub.user_info["user-1"].items() if k not in excluded}
         return User(**row)  # type: ignore[arg-type]
 

--- a/backend/main-backend/tests/test_avatar.py
+++ b/backend/main-backend/tests/test_avatar.py
@@ -1,0 +1,100 @@
+"""POST /api/v1/users/me/profile/avatar.
+
+Finding A: a brand-new user has no `profiles` row, and `update_profile` is an
+UPDATE that returns None when it matches zero rows -- the route 500ed before
+ever creating one, after the upload to storage had already succeeded.
+
+Finding B: the route returned the bare `profiles` row handed back by the
+write, and `full_name`/`username` are not columns there since migration 022
+-- every successful upload nulled the name in the response.
+"""
+
+import io
+from datetime import UTC, datetime
+
+import pytest
+from fastapi import status
+
+from app.core.supabase import supabase_client
+
+
+@pytest.fixture
+def stub_avatar_storage(monkeypatch, stub_supabase):
+    """Add the `profiles` slice and a fake `avatars` storage bucket.
+
+    Mirrors `stub_profiles` in test_profile.py, duplicated rather than
+    shared -- a fixture defined in a sibling test module is not visible
+    across files without moving it to conftest.py, and this one also needs
+    the storage-side stubs the profile tests don't.
+    """
+    rows: dict[str, dict[str, object]] = {}
+    stored_objects: set[str] = set()
+
+    def get_profile_by_id(user_id: str) -> dict[str, object] | None:
+        return rows.get(user_id)
+
+    def create_profile(user_id: str, **_: object) -> dict[str, object]:
+        # A real insert always carries created_at -- the column defaults to
+        # now() -- so the stub does too, to isolate the identity-overlay
+        # assertions in the tests below from an unrelated missing field.
+        rows[user_id] = {"id": user_id, "created_at": datetime.now(UTC).isoformat()}
+        return rows[user_id]
+
+    def update_profile(user_id: str, **fields: object) -> dict[str, object] | None:
+        # Real Supabase UPDATE: zero matched rows comes back as None.
+        row = rows.get(user_id)
+        if row is None:
+            return None
+        row.update({k: v for k, v in fields.items() if v is not None})
+        return row
+
+    def upload_avatar(user_id: str, file_content: bytes, file_extension: str) -> str:
+        url = f"https://stub.local/storage/v1/object/public/avatars/{user_id}/1.{file_extension}"
+        stored_objects.add(url)
+        return url
+
+    def delete_avatar(user_id: str, avatar_url: str) -> bool:
+        stored_objects.discard(avatar_url)
+        return True
+
+    monkeypatch.setattr(supabase_client, "get_profile_by_id", get_profile_by_id)
+    monkeypatch.setattr(supabase_client, "create_profile", create_profile)
+    monkeypatch.setattr(supabase_client, "update_profile", update_profile)
+    monkeypatch.setattr(supabase_client, "upload_avatar", upload_avatar)
+    monkeypatch.setattr(supabase_client, "delete_avatar", delete_avatar)
+
+    stub_supabase.profiles = rows
+    stub_supabase.stored_objects = stored_objects
+    return stub_supabase
+
+
+def _upload(client):
+    return client.post(
+        "/api/v1/users/me/profile/avatar",
+        files={"file": ("avatar.png", io.BytesIO(b"fake-image-bytes"), "image/png")},
+    )
+
+
+class TestAvatarUpload:
+    def test_upload_with_no_profiles_row_succeeds(self, client, stub_avatar_storage):
+        # The post-registration shape: no `profiles` row exists yet.
+        assert stub_avatar_storage.profiles == {}
+
+        response = _upload(client)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["avatar_url"] is not None
+
+    def test_upload_response_carries_identity_from_user_info(self, client, stub_avatar_storage):
+        stub_avatar_storage.profiles["user-1"] = {
+            "id": "user-1",
+            "created_at": datetime.now(UTC).isoformat(),
+        }
+        stub_avatar_storage.user_info["user-1"]["username"] = "snowking"
+
+        response = _upload(client)
+
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body["username"] == "snowking"
+        assert body["full_name"] == "Stub User"

--- a/backend/main-backend/tests/test_profile.py
+++ b/backend/main-backend/tests/test_profile.py
@@ -1,0 +1,117 @@
+"""GET and PUT /api/v1/users/me/profile, and GET /api/v1/users/{id}/profile.
+
+Migration 022 gives every user a `profiles` row and takes `full_name` and
+`username` off that table. The identity fields therefore have to be overlaid
+from `user_info` on every response -- a row that exists is not a reason to
+skip the overlay, it is the case that used to lose the name.
+"""
+
+import pytest
+from fastapi import status
+
+from app.api.v1 import users_profile_routes
+from app.core.supabase import supabase_client
+
+
+@pytest.fixture
+def stub_profiles(monkeypatch, stub_supabase):
+    """Add the `profiles` slice to the shared `user_info` stub.
+
+    Also bypasses the Redis-backed profile cache, so a test sees what the
+    route built rather than what a previous test left behind.
+    """
+    rows: dict[str, dict[str, object]] = {}
+
+    def get_profile_by_id(user_id: str) -> dict[str, object] | None:
+        return rows.get(user_id)
+
+    def create_profile(user_id: str, **_: object) -> dict[str, object]:
+        rows[user_id] = {"id": user_id}
+        return rows[user_id]
+
+    def update_profile(user_id: str, **fields: object) -> dict[str, object]:
+        row = rows.setdefault(user_id, {"id": user_id})
+        row.update({k: v for k, v in fields.items() if v is not None})
+        return row
+
+    monkeypatch.setattr(supabase_client, "get_profile_by_id", get_profile_by_id)
+    monkeypatch.setattr(supabase_client, "create_profile", create_profile)
+    monkeypatch.setattr(supabase_client, "update_profile", update_profile)
+    monkeypatch.setattr(users_profile_routes, "get_profile", lambda user_id: None)
+    monkeypatch.setattr(users_profile_routes, "set_profile", lambda user_id, profile: None)
+
+    stub_supabase.profiles = rows
+    return stub_supabase
+
+
+class TestProfileIdentityOverlay:
+    def test_a_user_with_a_profiles_row_still_gets_their_name(self, client, stub_profiles):
+        # The post-022 shape: a real row, carrying none of the identity.
+        stub_profiles.profiles["user-1"] = {"id": "user-1", "bio": "Powder only"}
+        stub_profiles.user_info["user-1"]["username"] = "snowking"
+
+        response = client.get("/api/v1/users/me/profile")
+
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body["username"] == "snowking"
+        assert body["full_name"] == "Stub User"
+        assert body["bio"] == "Powder only"
+
+    def test_a_user_with_no_profiles_row_gets_their_name_too(self, client, stub_profiles):
+        stub_profiles.user_info["user-1"]["username"] = "snowking"
+
+        response = client.get("/api/v1/users/me/profile")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["username"] == "snowking"
+        assert response.json()["full_name"] == "Stub User"
+
+    def test_the_country_setting_reads_back(self, client, stub_profiles):
+        # country_code moved to user_info in 021 and is never on the row.
+        stub_profiles.profiles["user-1"] = {"id": "user-1"}
+        stub_profiles.user_info["user-1"]["country_code"] = "CH"
+
+        assert client.get("/api/v1/users/me/profile").json()["country_code"] == "CH"
+
+    def test_a_save_returns_the_name_it_did_not_write(self, client, stub_profiles):
+        stub_profiles.profiles["user-1"] = {"id": "user-1"}
+        stub_profiles.user_info["user-1"]["username"] = "snowking"
+
+        response = client.put("/api/v1/users/me/profile", json={"bio": "Powder only"})
+
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body["username"] == "snowking"
+        assert body["full_name"] == "Stub User"
+        assert body["bio"] == "Powder only"
+
+    def test_another_users_profile_carries_their_handle(self, client, stub_profiles):
+        stub_profiles.user_info["user-2"] = {
+            "id": "user-2",
+            "email": "user-2@example.com",
+            "first_name": "Other",
+            "last_name": "Skier",
+            "username": "carver",
+        }
+        stub_profiles.profiles["user-2"] = {"id": "user-2"}
+
+        response = client.get("/api/v1/users/user-2/profile")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["username"] == "carver"
+
+    def test_an_unknown_user_is_not_found(self, client, stub_profiles):
+        response = client.get("/api/v1/users/nobody/profile")
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_full_name_is_not_settable_here(self, client, stub_profiles):
+        # It lives on user_info now; PUT /users/me is where it is written.
+        response = client.put(
+            "/api/v1/users/me/profile",
+            json={"bio": "x", "full_name": "Someone Else"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["full_name"] == "Stub User"

--- a/backend/main-backend/tests/test_username.py
+++ b/backend/main-backend/tests/test_username.py
@@ -28,6 +28,14 @@ class TestSetUsername:
 
         assert response.status_code == status.HTTP_409_CONFLICT
 
+    def test_resubmitting_your_own_handle_is_not_a_conflict(self, client, stub_supabase):
+        stub_supabase.user_info["user-1"]["username"] = "snowking"
+
+        response = client.put("/api/v1/users/me/username", json={"username": "snowking"})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["username"] == "snowking"
+
     def test_null_clears_it(self, client, stub_supabase):
         response = client.put("/api/v1/users/me/username", json={"username": None})
 

--- a/backend/main-backend/tests/test_username.py
+++ b/backend/main-backend/tests/test_username.py
@@ -1,0 +1,40 @@
+"""PUT /api/v1/users/me/username.
+
+The username is the identity every surface shows, so it is unique, lower
+case, and its own route -- next to /me/privacy and /me/country, the two
+other settings that live on user_info.
+"""
+
+from fastapi import status
+
+
+class TestSetUsername:
+    def test_sets_a_username(self, client, stub_supabase):
+        response = client.put("/api/v1/users/me/username", json={"username": "snowking"})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["username"] == "snowking"
+
+    def test_stores_it_lower_cased(self, client, stub_supabase):
+        # One spelling, so the mention parser has one thing to match.
+        response = client.put("/api/v1/users/me/username", json={"username": "SnowKing"})
+
+        assert response.json()["username"] == "snowking"
+
+    def test_a_taken_handle_is_a_conflict(self, client, stub_supabase):
+        stub_supabase.taken_usernames.add("snowking")
+
+        response = client.put("/api/v1/users/me/username", json={"username": "snowking"})
+
+        assert response.status_code == status.HTTP_409_CONFLICT
+
+    def test_null_clears_it(self, client, stub_supabase):
+        response = client.put("/api/v1/users/me/username", json={"username": None})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["username"] is None
+
+    def test_rejects_shapes_that_would_break_a_mention(self, client, stub_supabase):
+        for bad in ("ab", "a" * 21, "snow king", "snow.king", "snow-king"):
+            response = client.put("/api/v1/users/me/username", json={"username": bad})
+            assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, bad

--- a/backend/shared/display_name.py
+++ b/backend/shared/display_name.py
@@ -1,0 +1,56 @@
+"""How a person is named on screen.
+
+One rule, stated in
+docs/superpowers/specs/2026-09-04-profiles-repair-design.md and implemented
+here for every surface that sends a finished name. The community feed sends
+raw fields instead and resolves the same rule in Dart; the two are tested
+against the same cases.
+"""
+
+#: Shown for an author who is gone, or who has nothing to be named by.
+UNKNOWN_PLAYER = "Skier"
+
+
+def display_name(
+    *,
+    username: str | None,
+    first_name: str | None,
+    last_name: str | None,
+    email: str | None,
+    deleted: bool = False,
+) -> str:
+    """The name to show for one person.
+
+    Args:
+        username: The handle they chose, if any.
+        first_name: Their given name.
+        last_name: Their family name.
+        email: Their address, used only for its handle.
+        deleted: Whether the account is gone. Outranks everything else --
+            a cached row can still carry the old name, and none of it may
+            be shown.
+
+    Returns:
+        `@handle` when a username is set, their name when it is not, the
+        email handle when there is neither, and `UNKNOWN_PLAYER` when there
+        is nothing at all. The `@` marks a handle and never a person, so it
+        appears on the first rung only.
+    """
+    if deleted:
+        return UNKNOWN_PLAYER
+
+    handle = (username or "").strip()
+    if handle:
+        return f"@{handle}"
+
+    first = (first_name or "").strip()
+    last = (last_name or "").strip()
+    full = " ".join(part for part in (first, last) if part)
+    if full:
+        return full
+
+    address = (email or "").strip()
+    if "@" in address:
+        return address.split("@")[0]
+
+    return UNKNOWN_PLAYER

--- a/backend/shared/tests/test_display_name.py
+++ b/backend/shared/tests/test_display_name.py
@@ -1,0 +1,71 @@
+"""The display ladder.
+
+One rule, four rungs, and the `@` belongs to the first rung only. This is
+the Python half; `CommunityAuthorMapper.authorDisplayName` is the Dart half
+and is tested against the same four cases.
+"""
+
+from shared.display_name import UNKNOWN_PLAYER, display_name
+
+
+def test_a_chosen_username_wins_and_carries_the_at_sign():
+    assert (
+        display_name(
+            username="snowking",
+            first_name="Matthew",
+            last_name="Ng",
+            email="matthew@example.com",
+        )
+        == "@snowking"
+    )
+
+
+def test_without_a_username_the_name_shows_with_no_at_sign():
+    # "@Matthew Ng" would be wrong: the @ marks a handle, not a person.
+    assert (
+        display_name(
+            username=None,
+            first_name="Matthew",
+            last_name="Ng",
+            email="matthew@example.com",
+        )
+        == "Matthew Ng"
+    )
+
+
+def test_with_neither_it_falls_back_to_the_email_handle():
+    assert (
+        display_name(
+            username=None,
+            first_name=None,
+            last_name=None,
+            email="skier@example.com",
+        )
+        == "skier"
+    )
+
+
+def test_a_deleted_author_outranks_everything_it_still_carries():
+    # A cached row can still hold the old name. None of it may be shown.
+    assert (
+        display_name(
+            username="snowking",
+            first_name="Matthew",
+            last_name="Ng",
+            email="matthew@example.com",
+            deleted=True,
+        )
+        == UNKNOWN_PLAYER
+    )
+
+
+def test_blank_strings_count_as_absent():
+    # Supabase returns "" rather than null for a cleared text field often
+    # enough that treating them differently is a bug waiting to happen.
+    assert display_name(username="  ", first_name="", last_name="", email="a@b.co") == "a"
+
+
+def test_nothing_at_all_still_returns_something_printable():
+    assert (
+        display_name(username=None, first_name=None, last_name=None, email=None) == UNKNOWN_PLAYER
+    )

--- a/docs/database_schema.md
+++ b/docs/database_schema.md
@@ -1,6 +1,6 @@
 # Supabase schema
 
-What the live database contains, as of 2026-08-27.
+What the live database contains, as of 2026-09-05.
 
 **This is a record, not a migration.** It is not runnable and must never
 be treated as something to apply. Changing the database means changing it
@@ -34,13 +34,13 @@ defines them and no test asserts their shape.
 | `name` | text | yes |  |  |
 | `description` | text | yes |  |  |
 | `distance_meters` | numeric | no | `0` |  |
-| `duration_seconds` | int32 | no | `0` |  |
+| `duration_seconds` | integer | no | `0` |  |
 | `elevation_gain_meters` | numeric | no | `0` |  |
 | `start_time` | timestamp with time zone | no |  |  |
 | `end_time` | timestamp with time zone | no |  |  |
 | `average_pace` | numeric | yes | `0` |  |
 | `max_pace` | numeric | yes | `0` |  |
-| `calories` | int32 | yes |  |  |
+| `calories` | integer | yes |  |  |
 | `created_at` | timestamp with time zone | no | `now()` |  |
 | `updated_at` | timestamp with time zone | no | `now()` |  |
 | `gps_path` | json[] | no |  |  |
@@ -49,6 +49,7 @@ defines them and no test asserts their shape.
 | `storage_key` | text | yes |  |  |
 | `processing_status` | text | no | `ready` |  |
 | `thumbnail_url` | text | yes |  |  |
+| `on_leaderboard` | boolean | no | `false` |  |
 
 ### `activity_comments`
 
@@ -82,7 +83,7 @@ defines them and no test asserts their shape.
 | `accuracy` | numeric | yes |  |  |
 | `speed` | numeric | yes |  |  |
 | `timestamp` | timestamp with time zone | no |  |  |
-| `sequence_order` | int32 | no |  |  |
+| `sequence_order` | integer | no |  |  |
 | `created_at` | timestamp with time zone | no | `now()` |  |
 
 ### `activity_shares`
@@ -128,13 +129,31 @@ defines them and no test asserts their shape.
 | `created_at` | timestamp with time zone | no | `now()` |  |
 | `updated_at` | timestamp with time zone | no | `now()` |  |
 
+### `duels`
+
+| Column | Type | Null | Default | Key |
+|---|---|---|---|---|
+| `id` | uuid | no | `gen_random_uuid()` | PK |
+| `challenger_id` | uuid | no |  | FK → `user_info.id` |
+| `opponent_id` | uuid | no |  | FK → `user_info.id` |
+| `metric` | text | no |  |  |
+| `duration` | text | no |  |  |
+| `status` | text | no | `pending` |  |
+| `starts_at` | timestamp with time zone | yes |  |  |
+| `ends_at` | timestamp with time zone | yes |  |  |
+| `challenger_value` | double precision | yes |  |  |
+| `opponent_value` | double precision | yes |  |  |
+| `winner_id` | uuid | yes |  | FK → `user_info.id` |
+| `created_at` | timestamp with time zone | no | `now()` |  |
+| `settled_at` | timestamp with time zone | yes |  |  |
+
 ### `follow_counts`
 
 | Column | Type | Null | Default | Key |
 |---|---|---|---|---|
 | `user_id` | uuid | no |  | PK |
-| `follower_count` | int32 | no | `0` |  |
-| `following_count` | int32 | no | `0` |  |
+| `follower_count` | integer | no | `0` |  |
+| `following_count` | integer | no | `0` |  |
 
 ### `follow_requests`
 
@@ -151,6 +170,17 @@ defines them and no test asserts their shape.
 | `follower_id` | uuid | no |  | PK |
 | `followee_id` | uuid | no |  | PK |
 | `created_at` | timestamp with time zone | no | `now()` |  |
+
+### `leaderboard_weeks`
+
+| Column | Type | Null | Default | Key |
+|---|---|---|---|---|
+| `week_start` | date | no |  | PK |
+| `metric` | text | no |  | PK |
+| `scope` | text | no |  | PK |
+| `rank` | integer | no |  | PK |
+| `user_id` | uuid | no |  | FK → `user_info.id` |
+| `value` | double precision | no |  |  |
 
 ### `post_likes`
 
@@ -194,8 +224,6 @@ defines them and no test asserts their shape.
 | Column | Type | Null | Default | Key |
 |---|---|---|---|---|
 | `id` | uuid | no |  | PK |
-| `full_name` | text | yes |  |  |
-| `username` | text | yes |  |  |
 | `bio` | text | yes |  |  |
 | `avatar_url` | text | yes |  |  |
 | `push_token` | text | yes |  |  |
@@ -203,6 +231,7 @@ defines them and no test asserts their shape.
 | `home` | text | yes |  |  |
 | `created_at` | timestamp with time zone | yes | `now()` |  |
 | `updated_at` | timestamp with time zone | yes | `now()` |  |
+| `country_code` | character | yes |  |  |
 
 ### `subthreads`
 
@@ -227,6 +256,8 @@ defines them and no test asserts their shape.
 | `last_login_at` | timestamp with time zone | yes |  |  |
 | `hashed_password` | text | no |  |  |
 | `is_private` | boolean | no | `false` |  |
+| `country_code` | character | yes |  |  |
+| `username` | text | yes |  |  |
 
 ### `user_stats`
 
@@ -235,20 +266,20 @@ defines them and no test asserts their shape.
 | `user_id` | uuid | no |  | PK |
 | `week_start` | date | no |  |  |
 | `weekly_distance_km` | double precision | no | `0` |  |
-| `weekly_time_min` | int32 | no | `0` |  |
+| `weekly_time_min` | integer | no | `0` |  |
 | `weekly_elev_gain_m` | double precision | no | `0` |  |
-| `weekly_session_count` | int32 | no | `0` |  |
-| `last_week_session_count` | int32 | no | `0` |  |
+| `weekly_session_count` | integer | no | `0` |  |
+| `last_week_session_count` | integer | no | `0` |  |
 | `yearly_distance_km` | double precision | no | `0` |  |
-| `yearly_time_min` | int32 | no | `0` |  |
+| `yearly_time_min` | integer | no | `0` |  |
 | `yearly_elev_gain_m` | double precision | no | `0` |  |
-| `yearly_session_count` | int32 | no | `0` |  |
+| `yearly_session_count` | integer | no | `0` |  |
 | `all_time_distance_km` | double precision | no | `0` |  |
-| `all_time_time_min` | int32 | no | `0` |  |
+| `all_time_time_min` | integer | no | `0` |  |
 | `all_time_elev_gain_m` | double precision | no | `0` |  |
-| `all_time_session_count` | int32 | no | `0` |  |
-| `current_streak_weeks` | int32 | no | `0` |  |
-| `longest_streak_weeks` | int32 | no | `0` |  |
+| `all_time_session_count` | integer | no | `0` |  |
+| `current_streak_weeks` | integer | no | `0` |  |
+| `longest_streak_weeks` | integer | no | `0` |  |
 | `activity_days` | text[] | no |  |  |
 | `best_efforts` | jsonb | no |  |  |
 | `updated_at` | timestamp with time zone | no | `now()` |  |
@@ -262,7 +293,7 @@ revision, not in the dashboard.
 
 | Column | Type | Null | Default | Key |
 |---|---|---|---|---|
-| `id` | int64 | no |  | PK |
+| `id` | bigint | no |  | PK |
 | `location` | public.geography(Point,4326) | no |  |  |
 | `elevation_meters` | double precision | no |  |  |
 | `source` | text | no | `google_elevation` |  |
@@ -272,12 +303,12 @@ revision, not in the dashboard.
 
 | Column | Type | Null | Default | Key |
 |---|---|---|---|---|
-| `id` | int64 | no |  | PK |
+| `id` | bigint | no |  | PK |
 | `cache_key` | text | no |  |  |
 | `center` | public.geography(Point,4326) | no |  |  |
-| `zoom` | int32 | no |  |  |
-| `width` | int32 | no |  |  |
-| `height` | int32 | no |  |  |
+| `zoom` | integer | no |  |  |
+| `width` | integer | no |  |  |
+| `height` | integer | no |  |  |
 | `provider` | text | no | `google_static_maps` |  |
 | `static_url` | text | no |  |  |
 | `expires_at` | timestamp with time zone | yes |  |  |

--- a/docs/service-ownership.md
+++ b/docs/service-ownership.md
@@ -18,6 +18,10 @@ One specific backend for each service (activity-related, main-backend handling u
 - A domain is exposed by exactly one service.
 - No duplicate route ownership across services.
 - Frontend routes by domain, not by implementation details.
+- display identity: `user_info`. A user's chosen `username` is what every
+  surface shows, so it lives beside `is_private` and `country_code` rather
+  than in `profiles`. The rule: `user_info` holds what other services read,
+  `profiles` holds what only the profile screen reads.
 
 ## Canonical Base Paths
 

--- a/docs/superpowers/plans/2026-09-04-profiles-repair.md
+++ b/docs/superpowers/plans/2026-09-04-profiles-repair.md
@@ -1,0 +1,1168 @@
+# Profiles Repair and Username Identity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `profiles` can be written again, and a user's chosen username is
+the name every surface shows.
+
+**Architecture:** `profiles.id` is re-pointed from Supabase auth's `users` to
+`user_info(id)` and backfilled. `username` moves to `user_info`, where every
+service already reads, and `full_name` is dropped because it duplicates
+`first_name` and `last_name`. One display ladder — username, then name, then
+email handle, then placeholder — implemented once in Python for surfaces
+that send a finished name and once in Dart for the community feed, which
+sends raw fields.
+
+**Tech Stack:** Postgres via Supabase, FastAPI (main-, community-,
+activity-backend), Flutter/Dart.
+
+**Spec:** `docs/superpowers/specs/2026-09-04-profiles-repair-design.md`
+
+## Global Constraints
+
+- Python 3.11. `ruff check .` and `ruff format --check .` from `backend/`
+  must pass; line length 100, double quotes.
+- Backend tests run from the service directory with `PYTHONPATH=.:..`.
+  main-backend also needs `-o addopts=""`.
+- Dart: single quotes, return types declared. Colours from `context.colors`.
+- snake_case on the wire. A response-shape change is a two-sided break.
+- No new runtime dependency, Python or pub, without asking.
+- Migration 022 is hand-applied in the Supabase SQL editor. Do **not** run
+  it; hand it over and wait.
+- Never touch `.env`, `postgres.env`, or anything `check_secrets.sh` guards.
+- The display ladder, verbatim, and the only place it is stated:
+
+  ```text
+  @username      when the user has set one
+  First Last     when they have not
+  email handle   when they have neither
+  Skier          when the author is gone entirely
+  ```
+
+  The `@` appears on the first rung only.
+- Usernames are stored lower-cased, 3-20 characters, `[a-z0-9_]`.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `backend/db/migrations/022_profiles_repair.sql` | Re-point the FK, backfill, move `username`, drop `full_name` |
+| `backend/shared/display_name.py` | The ladder, as one pure function |
+| `backend/main-backend/app/core/supabase/users.py` | `set_username`, `username_exists` against `user_info` |
+| `backend/main-backend/app/api/v1/users_profile_routes.py` | `PUT /me/username` |
+| `backend/*/services/*.py` | Carry `username` through every author read |
+| `frontend/lib/screens/community/mappers/community_author_mapper.dart` | The ladder in Dart |
+
+---
+
+### Task 1: Migration 022
+
+**Files:**
+- Create: `backend/db/migrations/022_profiles_repair.sql`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `profiles` holds one row per user and cascades with them;
+  `user_info.username` exists and is uniquely indexed on `lower(username)`;
+  `profiles.full_name` and `profiles.username` are gone.
+
+- [ ] **Step 1: Write the migration**
+
+Create `backend/db/migrations/022_profiles_repair.sql`:
+
+```sql
+-- Run this in the Supabase SQL editor after 021.
+--
+-- profiles.id references Supabase auth's `users`, but registration writes
+-- `user_info`, so every insert fails with 23503 and the table has never held
+-- a row: 41 users, 0 profiles. Every profile edit returns 500 and every
+-- uploaded avatar URL is discarded.
+--
+-- Repairing it as-is would be worse. profiles is read by one file;
+-- user_info is read by ten across three services, and every displayed name
+-- already comes from it. Keeping full_name creates a second source for one
+-- fact, and the profile screen and the feed would disagree silently.
+--
+-- One rule decides where a column lives: user_info holds what other services
+-- read, profiles holds what only the profile screen reads.
+--
+-- Design: docs/superpowers/specs/2026-09-04-profiles-repair-design.md
+
+begin;
+
+alter table profiles drop constraint profiles_id_fkey;
+alter table profiles add constraint profiles_id_fkey
+  foreign key (id) references user_info(id) on delete cascade;
+
+-- One profile per existing user. Ids only: usernames are chosen, never
+-- generated. Deriving them from email addresses would mint handles nobody
+-- picked, collide across domains, and leak the real names the field exists
+-- to hide.
+insert into profiles (id)
+select id from user_info
+on conflict (id) do nothing;
+
+-- The second source for a name, removed before anything can write to it.
+alter table profiles drop column full_name;
+
+-- The displayed identity moves to where every service already reads. Unique
+-- on lower(username) so SnowKing and snowking cannot both exist, and partial
+-- so the null usernames do not collide with each other.
+alter table user_info add column if not exists username text;
+create unique index if not exists user_info_username_key
+  on user_info (lower(username)) where username is not null;
+
+alter table profiles drop column username;
+
+commit;
+```
+
+- [ ] **Step 2: Renumber the account deletion migration**
+
+`docs/superpowers/plans/2026-09-04-account-deletion.md`, on branch
+`feat/account-deletion`, also claims 022. This change lands first, so that
+one becomes **023**. It also gains a line, because `profiles` now holds rows
+and has to go with its user — the re-pointed foreign key above already does
+that, so the note is only to stop somebody adding a second rule for it.
+
+If that branch is not checked out, do not switch to it. Say so in the
+summary and leave it: renumbering a file on another branch from here is how
+two people end up editing the same line.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/db/migrations/022_profiles_repair.sql
+git commit -m "feat(profiles): re-point profiles at user_info in migration 022"
+```
+
+- [ ] **Step 4: Hand it over and stop**
+
+Say: "Migration 022 is ready at
+`backend/db/migrations/022_profiles_repair.sql`. Run it in the Supabase SQL
+editor, then tell me — nothing after this can be verified until it is
+applied."
+
+Do **not** run it. Do not start Task 2 until the user confirms.
+
+- [ ] **Step 5: Verify after the user confirms**
+
+From `backend/activity-backend`:
+
+```bash
+PYTHONPATH=.:.. ../../.venv/bin/python - <<'PY'
+from config import get_config
+from supabase import create_client
+
+c = get_config()
+client = create_client(c.SUPABASE_URL, c.SUPABASE_SERVICE_ROLE_KEY)
+
+users = client.table("user_info").select("id", count="exact").limit(1).execute()
+profs = client.table("profiles").select("id", count="exact").limit(1).execute()
+print("user_info:", users.count, "profiles:", profs.count)
+
+row = client.table("user_info").select("id,username").limit(1).execute().data[0]
+print("user_info has username column:", "username" in row)
+
+cols = client.table("profiles").select("*").limit(1).execute().data[0]
+print("profiles dropped full_name:", "full_name" not in cols)
+print("profiles dropped username:", "username" not in cols)
+PY
+```
+
+Expected:
+
+```
+user_info: 41 profiles: 41
+user_info has username column: True
+profiles dropped full_name: True
+profiles dropped username: True
+```
+
+Any mismatch means the migration did not fully apply. Stop and report it.
+
+---
+
+### Task 2: The display ladder, in Python
+
+**Files:**
+- Create: `backend/shared/display_name.py`
+- Test: `backend/shared/tests/test_display_name.py`
+- Modify: `backend/activity-backend/services/leaderboard_operations.py`
+  (`display_fields` delegates to it)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `shared.display_name.display_name(*, username, first_name,
+  last_name, email, deleted=False) -> str`, and the constant
+  `shared.display_name.UNKNOWN_PLAYER`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/shared/tests/test_display_name.py`:
+
+```python
+"""The display ladder.
+
+One rule, four rungs, and the `@` belongs to the first rung only. This is
+the Python half; `CommunityAuthorMapper.authorDisplayName` is the Dart half
+and is tested against the same four cases.
+"""
+
+from shared.display_name import UNKNOWN_PLAYER, display_name
+
+
+def test_a_chosen_username_wins_and_carries_the_at_sign():
+    assert (
+        display_name(
+            username="snowking",
+            first_name="Matthew",
+            last_name="Ng",
+            email="matthew@example.com",
+        )
+        == "@snowking"
+    )
+
+
+def test_without_a_username_the_name_shows_with_no_at_sign():
+    # "@Matthew Ng" would be wrong: the @ marks a handle, not a person.
+    assert (
+        display_name(
+            username=None,
+            first_name="Matthew",
+            last_name="Ng",
+            email="matthew@example.com",
+        )
+        == "Matthew Ng"
+    )
+
+
+def test_with_neither_it_falls_back_to_the_email_handle():
+    assert (
+        display_name(
+            username=None, first_name=None, last_name=None,
+            email="skier@example.com",
+        )
+        == "skier"
+    )
+
+
+def test_a_deleted_author_outranks_everything_it_still_carries():
+    # A cached row can still hold the old name. None of it may be shown.
+    assert (
+        display_name(
+            username="snowking",
+            first_name="Matthew",
+            last_name="Ng",
+            email="matthew@example.com",
+            deleted=True,
+        )
+        == UNKNOWN_PLAYER
+    )
+
+
+def test_blank_strings_count_as_absent():
+    # Supabase returns "" rather than null for a cleared text field often
+    # enough that treating them differently is a bug waiting to happen.
+    assert (
+        display_name(username="  ", first_name="", last_name="", email="a@b.co")
+        == "a"
+    )
+
+
+def test_nothing_at_all_still_returns_something_printable():
+    assert (
+        display_name(username=None, first_name=None, last_name=None, email=None)
+        == UNKNOWN_PLAYER
+    )
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+```bash
+cd backend/shared
+PYTHONPATH=.:.. ../../.venv/bin/python -m pytest tests/test_display_name.py -q
+```
+
+Expected: FAIL — `ModuleNotFoundError: No module named 'shared.display_name'`.
+If `backend/shared/tests/` does not exist, create it with an empty
+`__init__.py` first.
+
+- [ ] **Step 3: Write the ladder**
+
+Create `backend/shared/display_name.py`:
+
+```python
+"""How a person is named on screen.
+
+One rule, stated in
+docs/superpowers/specs/2026-09-04-profiles-repair-design.md and implemented
+here for every surface that sends a finished name. The community feed sends
+raw fields instead and resolves the same rule in Dart; the two are tested
+against the same cases.
+"""
+
+#: Shown for an author who is gone, or who has nothing to be named by.
+UNKNOWN_PLAYER = "Skier"
+
+
+def display_name(
+    *,
+    username: str | None,
+    first_name: str | None,
+    last_name: str | None,
+    email: str | None,
+    deleted: bool = False,
+) -> str:
+    """The name to show for one person.
+
+    Args:
+        username: The handle they chose, if any.
+        first_name: Their given name.
+        last_name: Their family name.
+        email: Their address, used only for its handle.
+        deleted: Whether the account is gone. Outranks everything else --
+            a cached row can still carry the old name, and none of it may
+            be shown.
+
+    Returns:
+        `@handle` when a username is set, their name when it is not, the
+        email handle when there is neither, and `UNKNOWN_PLAYER` when there
+        is nothing at all. The `@` marks a handle and never a person, so it
+        appears on the first rung only.
+    """
+    if deleted:
+        return UNKNOWN_PLAYER
+
+    handle = (username or "").strip()
+    if handle:
+        return f"@{handle}"
+
+    first = (first_name or "").strip()
+    last = (last_name or "").strip()
+    full = " ".join(part for part in (first, last) if part)
+    if full:
+        return full
+
+    address = (email or "").strip()
+    if "@" in address:
+        return address.split("@")[0]
+
+    return UNKNOWN_PLAYER
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+```bash
+cd backend/shared
+PYTHONPATH=.:.. ../../.venv/bin/python -m pytest tests/test_display_name.py -q
+```
+
+Expected: 6 passed.
+
+- [ ] **Step 5: Delegate the leaderboard's copy to it**
+
+In `backend/activity-backend/services/leaderboard_operations.py`, replace the
+body of `display_fields` and drop the local `UNKNOWN_PLAYER`:
+
+```python
+from shared.display_name import UNKNOWN_PLAYER, display_name
+```
+
+```python
+def display_fields(user: dict[str, Any]) -> dict[str, Any]:
+    """The public half of a user, for a board row or a duel card.
+
+    A board shows a name and a country. It never shows an activity, which is
+    what lets a private activity count towards a total without leaking
+    anything about itself.
+
+    ponytail: avatar_url is always null. Uploaded avatars are written to
+    `profiles.avatar_url`, and until migration 022 that row never existed --
+    issue #43. Fill it in when the community payload carries an avatar; do
+    not invent a second place to keep it.
+    """
+    username = (user.get("username") or "").strip() or None
+    return {
+        "display_name": display_name(
+            username=username,
+            first_name=user.get("first_name"),
+            last_name=user.get("last_name"),
+            email=user.get("email"),
+        ),
+        "username": username,
+        "avatar_url": None,
+        "country_code": user.get("country_code"),
+    }
+```
+
+`display_fields` no longer references `UNKNOWN_PLAYER` directly, so leaving
+it imported here would trip ruff's F401. Import only `display_name` in this
+file, and point the one other user at the source:
+
+```bash
+grep -rn UNKNOWN_PLAYER backend/activity-backend
+```
+
+`routes/duel_routes.py` imports it from `services.leaderboard_operations`.
+Change that line to `from shared.display_name import UNKNOWN_PLAYER`. A
+re-export would work and would also be a second place to look when somebody
+asks where the placeholder is defined.
+
+- [ ] **Step 6: Update the two board tests that assert on names**
+
+`backend/activity-backend/tests/test_competition_operations.py` has
+`test_a_board_row_names_a_user_from_user_info` and
+`test_a_nameless_user_falls_back_to_their_email_handle`. Add a third and
+leave the two alone — they still pass, because neither fixture sets a
+username:
+
+```python
+    def test_a_chosen_username_is_what_the_board_shows(self):
+        client = _FakeClient()
+        client.rpc_results["leaderboard_top"] = [
+            {"rank": 1, "user_id": ALEX, "value": 900.0}
+        ]
+        client.rows["user_info"] = [
+            {
+                "id": ALEX,
+                "username": "snowking",
+                "first_name": "Alpha",
+                "last_name": "Tester",
+                "email": "alpha@example.com",
+            }
+        ]
+
+        entry = LeaderboardOperations(client).top(
+            Metric.VERTICAL, GLOBAL_SCOPE, NOW
+        )[0]
+
+        assert entry["display_name"] == "@snowking"
+        assert entry["username"] == "snowking"
+```
+
+Add `username` to `_USER_COLUMNS` in `leaderboard_operations.py`:
+
+```python
+    _USER_COLUMNS = "id,username,first_name,last_name,email,country_code"
+```
+
+And to the select in `DuelOperations.players`:
+
+```python
+                .select("id,username,first_name,last_name,email")
+```
+
+- [ ] **Step 7: Run both suites**
+
+```bash
+cd backend/shared && PYTHONPATH=.:.. ../../.venv/bin/python -m pytest -q
+cd ../activity-backend && PYTHONPATH=.:.. ../../.venv/bin/python -m pytest -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/shared/ backend/activity-backend/
+git commit -m "feat(shared): put the display ladder in one function"
+```
+
+---
+
+### Task 3: `PUT /api/v1/users/me/username`
+
+**Files:**
+- Modify: `backend/main-backend/app/core/supabase/users.py`
+- Modify: `backend/main-backend/app/core/supabase/profiles.py`
+  (`update_profile` drops `full_name` and `username`; delete
+  `username_exists` from here)
+- Modify: `backend/main-backend/app/api/v1/users_profile_routes.py`
+- Modify: `backend/main-backend/app/schemas/__init__.py`
+- Test: `backend/main-backend/tests/test_username.py`
+
+**Interfaces:**
+- Consumes: Task 1's `user_info.username` column and unique index.
+- Produces: `supabase_client.set_username(id, username) -> bool`,
+  `supabase_client.username_exists(username, exclude_user_id=None) -> bool`
+  reading `user_info`, and `PUT /api/v1/users/me/username` taking
+  `{"username": str | null}`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/main-backend/tests/test_username.py`:
+
+```python
+"""PUT /api/v1/users/me/username.
+
+The username is the identity every surface shows, so it is unique, lower
+case, and its own route -- next to /me/privacy and /me/country, the two
+other settings that live on user_info.
+"""
+
+from fastapi import status
+
+
+class TestSetUsername:
+    def test_sets_a_username(self, client, stub_supabase):
+        response = client.put(
+            "/api/v1/users/me/username", json={"username": "snowking"}
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["username"] == "snowking"
+
+    def test_stores_it_lower_cased(self, client, stub_supabase):
+        # One spelling, so the mention parser has one thing to match.
+        response = client.put(
+            "/api/v1/users/me/username", json={"username": "SnowKing"}
+        )
+
+        assert response.json()["username"] == "snowking"
+
+    def test_a_taken_handle_is_a_conflict(self, client, stub_supabase):
+        stub_supabase.taken_usernames.add("snowking")
+
+        response = client.put(
+            "/api/v1/users/me/username", json={"username": "snowking"}
+        )
+
+        assert response.status_code == status.HTTP_409_CONFLICT
+
+    def test_null_clears_it(self, client, stub_supabase):
+        response = client.put("/api/v1/users/me/username", json={"username": None})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["username"] is None
+
+    def test_rejects_shapes_that_would_break_a_mention(self, client, stub_supabase):
+        for bad in ("ab", "a" * 21, "snow king", "snow.king", "snow-king"):
+            response = client.put(
+                "/api/v1/users/me/username", json={"username": bad}
+            )
+            assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, bad
+```
+
+Extend `_StubSupabase` in `backend/main-backend/tests/conftest.py`:
+
+```python
+        self.taken_usernames: set[str] = set()
+```
+
+```python
+    def username_exists(self, username: str, exclude_user_id: str | None = None) -> bool:
+        return username in self.taken_usernames
+
+    def set_username(self, id: str, username: str | None) -> bool:
+        row = self.user_info.get(id)
+        if row is None:
+            return False
+        row["username"] = username
+        return True
+```
+
+And register both in the `stub_supabase` fixture:
+
+```python
+    monkeypatch.setattr(supabase_client, "username_exists", stub.username_exists)
+    monkeypatch.setattr(supabase_client, "set_username", stub.set_username)
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+cd backend/main-backend
+PYTHONPATH=.:.. ../../.venv/bin/python -m pytest tests/test_username.py -q -o addopts=""
+```
+
+Expected: FAIL — 405, the route does not exist.
+
+- [ ] **Step 3: Add the schema**
+
+In `backend/main-backend/app/schemas/__init__.py`, after `ProfileUpdate`:
+
+```python
+class UsernameSetting(BaseModel):
+    """The handle this account is known by.
+
+    Lower case only, so `@snowking` has exactly one spelling and the mention
+    parser has one thing to match. Null clears it; the display falls back to
+    the user's name.
+    """
+
+    username: str | None = Field(
+        None,
+        min_length=3,
+        max_length=20,
+        pattern=r"^[a-zA-Z0-9_]+$",
+    )
+```
+
+Then remove `username` and `full_name` from `ProfileUpdate`, leaving
+`bio`, `avatar_url`, `push_token`, `ski_level` and `home`. Leave
+`ProfileResponse` alone: it still returns `full_name` and `username`, both
+now derived from `user_info`, so the Dart `Profile` model does not change.
+
+- [ ] **Step 4: Move the uniqueness check and add the write**
+
+In `backend/main-backend/app/core/supabase/users.py`, after
+`set_user_country`:
+
+```python
+    def username_exists(self, username: str, exclude_user_id: str | None = None) -> bool:
+        """Whether a handle is already taken, case-insensitively.
+
+        Lives here, not on profiles: `username` moved to `user_info` in
+        migration 022 because every service reads names from there.
+
+        Args:
+            username: The handle to check.
+            exclude_user_id: A user to ignore, so re-submitting your own
+                handle is not a conflict with yourself.
+
+        Returns:
+            True when taken. True on a failed read as well -- refusing a
+            free handle is recoverable, handing out a duplicate is not.
+        """
+        if not self.is_configured():
+            return False
+        client = self._client
+        if client is None:
+            return False
+        try:
+            query = client.table("user_info").select("id").ilike("username", username)
+            if exclude_user_id:
+                query = query.neq("id", exclude_user_id)
+            resp = query.limit(1).execute()
+            data = getattr(resp, "data", None)
+            return isinstance(data, list) and len(data) > 0
+        except Exception as exc:
+            logger.exception(f"Error checking username existence: {exc}")
+            return True
+
+    def set_username(self, id: str, username: str | None) -> bool:
+        """Set or clear the handle this account is known by.
+
+        Args:
+            id: The user.
+            username: The handle, already lower-cased and validated, or None
+                to clear it.
+
+        Returns:
+            True when a row was updated.
+        """
+        if not self.is_configured():
+            logger.warning("Supabase not configured; skipping set_username.")
+            return False
+        client = self._client
+        if client is None:
+            return False
+        try:
+            resp = (
+                client.table("user_info").update({"username": username}).eq("id", id).execute()
+            )
+            return bool(getattr(resp, "data", None))
+        except Exception as exc:
+            logger.exception(f"Failed to set username for user {id}: {exc}")
+            return False
+```
+
+Then delete `username_exists` from
+`backend/main-backend/app/core/supabase/profiles.py`, and remove `full_name`
+and `username` from `update_profile`'s signature, its docstring and its
+`update_data` block.
+
+- [ ] **Step 5: Add the route**
+
+In `users_profile_routes.py`, after `set_my_country`:
+
+```python
+@router.put("/me/username", response_model=UsernameSetting)
+def set_my_username(
+    setting: UsernameSetting,
+    current_user: User = Depends(get_current_user),
+) -> UsernameSetting:
+    """Choose the handle this account is known by.
+
+    Its own route rather than a field on PUT /me/profile, for the same
+    reason /me/privacy and /me/country are: those write `user_info`, and
+    that is where a name has to live for a feed to read it.
+
+    Stored lower-cased so `@snowking` has one spelling. Null clears it and
+    the display falls back to the user's name.
+
+    Raises:
+        HTTPException: 409 if another account already has the handle, 404 if
+            the user is gone.
+    """
+    _ensure_database_configured()
+
+    handle = setting.username.lower() if setting.username else None
+
+    if handle and supabase_client.username_exists(handle, exclude_user_id=current_user.id):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="That username is taken",
+        ) from None
+
+    if not supabase_client.set_username(current_user.id, handle):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found",
+        ) from None
+
+    invalidate_profile(current_user.id)
+    return UsernameSetting(username=handle)
+```
+
+Add `UsernameSetting` to the `from app.schemas import ...` line.
+
+Also update `_profile_from_user_info` in the same file so the fallback
+profile carries the real handle:
+
+```python
+        "username": user.get("username"),
+```
+
+replacing the line that derives it from the email.
+
+- [ ] **Step 6: Run to verify it passes**
+
+```bash
+cd backend/main-backend
+PYTHONPATH=.:.. ../../.venv/bin/python -m pytest tests/test_username.py -q -o addopts=""
+```
+
+Expected: 5 passed.
+
+- [ ] **Step 7: Run the whole suite and lint**
+
+```bash
+cd backend/main-backend
+PYTHONPATH=.:.. ../../.venv/bin/python -m pytest -q -o addopts=""
+.venv/bin/ruff check backend/
+```
+
+Expected: all pass. If a test asserted on `ProfileUpdate.full_name`, it now
+fails; delete that assertion — the field is gone on purpose.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/main-backend/
+git commit -m "feat(profiles): move username to user_info behind its own route"
+```
+
+---
+
+### Task 4: Carry the username through every author read
+
+**Files:**
+- Modify: `backend/community-backend/services/community_post_read_operations.py`
+- Modify:
+  `backend/community-backend/services/community_comment_read_operations.py`
+- Modify: `backend/main-backend/app/core/supabase/posts.py`
+- Modify: `backend/main-backend/app/core/supabase/comments.py`
+- Modify: `backend/community-backend/services/mappers/community_row_mappers.py`
+- Test: `backend/community-backend/tests/test_operations_units.py` (append)
+
+**Interfaces:**
+- Consumes: Task 1's `user_info.username`.
+- Produces: every post and comment payload carries `author_username`
+  alongside `author_email`, `author_first_name` and `author_last_name`.
+  Task 5 reads it.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/community-backend/tests/test_operations_units.py`:
+
+```python
+def test_the_author_username_reaches_the_client():
+    # The feed resolves the display ladder in Dart, so the handle has to be
+    # on the row. Without it a user who set @snowking still shows as their
+    # real name in every post.
+    from services.mappers.community_row_mappers import flatten_user_info
+
+    row = {
+        "post_id": "p1",
+        "user_info": {
+            "email": "matthew@example.com",
+            "first_name": "Matthew",
+            "last_name": "Ng",
+            "username": "snowking",
+        },
+    }
+
+    flatten_user_info(row)
+
+    assert row["author_username"] == "snowking"
+    assert row["author_first_name"] == "Matthew"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+cd backend/community-backend
+PYTHONPATH=.:.. ../../.venv/bin/python -m pytest tests/test_operations_units.py -k author_username -q
+```
+
+Expected: FAIL — `KeyError: 'author_username'`.
+
+- [ ] **Step 3: Flatten the new field**
+
+In `backend/community-backend/services/mappers/community_row_mappers.py`:
+
+```python
+    row["author_email"] = author.get("email")
+    row["author_first_name"] = author.get("first_name")
+    row["author_last_name"] = author.get("last_name")
+    row["author_username"] = author.get("username")
+```
+
+- [ ] **Step 4: Add `username` to all fourteen embeds**
+
+There are exactly two distinct strings, eight and six occurrences:
+
+```bash
+cd /Users/matthewng/Desktop/Snowtrak
+grep -rl 'user_info!posts_user_id_fkey(email, first_name, last_name)' backend --include=*.py \
+  | xargs sed -i '' 's/user_info!posts_user_id_fkey(email, first_name, last_name)/user_info!posts_user_id_fkey(email, first_name, last_name, username)/g'
+grep -rl 'user_info!comments_user_id_fkey(email, first_name, last_name)' backend --include=*.py \
+  | xargs sed -i '' 's/user_info!comments_user_id_fkey(email, first_name, last_name)/user_info!comments_user_id_fkey(email, first_name, last_name, username)/g'
+```
+
+Verify the count, which must be 14 and 0:
+
+```bash
+grep -rc 'first_name, last_name, username)' backend --include=*.py | grep -v ':0'
+grep -rn 'first_name, last_name)' backend --include=*.py | grep user_info
+```
+
+The second command must print nothing.
+
+- [ ] **Step 5: Run both suites**
+
+```bash
+cd backend/community-backend && PYTHONPATH=.:.. ../../.venv/bin/python -m pytest -q
+cd ../main-backend && PYTHONPATH=.:.. ../../.venv/bin/python -m pytest -q -o addopts=""
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/community-backend/ backend/main-backend/
+git commit -m "feat(community): carry the author username to the client"
+```
+
+---
+
+### Task 5: The ladder in Dart
+
+**Files:**
+- Modify: `frontend/lib/screens/community/mappers/community_author_mapper.dart`
+- Modify: `frontend/lib/screens/community/community_post_mapper.dart`
+- Modify:
+  `frontend/lib/screens/community/mappers/community_comment_tree_mapper.dart`
+- Modify: `frontend/lib/screens/community/mappers/community_quote_mapper.dart`
+- Modify: `frontend/lib/screens/community/thread_detail_screen.dart:62`
+- Modify: `frontend/lib/screens/profile/edit_profile_screen.dart`
+- Modify: `frontend/lib/services/apis/users_api.dart`
+- Test: `frontend/test/screens/community/community_author_mapper_test.dart`
+
+**Interfaces:**
+- Consumes: Task 4's `author_username`, Task 3's `PUT /me/username`.
+- Produces: `CommunityAuthorMapper.authorDisplayName({String? username,
+  String? firstName, String? lastName, required String fallback}) -> String`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `frontend/test/screens/community/community_author_mapper_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:snowtrak/screens/community/mappers/community_author_mapper.dart';
+
+void main() {
+  // The same four cases the Python half is tested against. Two
+  // implementations of one rule is the cost of the community feed sending
+  // raw fields; testing them identically is what keeps them honest.
+  test('a chosen username wins and carries the at sign', () {
+    expect(
+      CommunityAuthorMapper.authorDisplayName(
+        username: 'snowking',
+        firstName: 'Matthew',
+        lastName: 'Ng',
+        fallback: 'matthew@example.com',
+      ),
+      '@snowking',
+    );
+  });
+
+  test('without a username the name shows with no at sign', () {
+    expect(
+      CommunityAuthorMapper.authorDisplayName(
+        username: null,
+        firstName: 'Matthew',
+        lastName: 'Ng',
+        fallback: 'matthew@example.com',
+      ),
+      'Matthew Ng',
+    );
+  });
+
+  test('with neither it falls back to the email handle', () {
+    expect(
+      CommunityAuthorMapper.authorDisplayName(
+        username: null,
+        firstName: null,
+        lastName: null,
+        fallback: 'skier@example.com',
+      ),
+      'skier',
+    );
+  });
+
+  test('a blank username counts as absent', () {
+    expect(
+      CommunityAuthorMapper.authorDisplayName(
+        username: '   ',
+        firstName: 'Matthew',
+        lastName: 'Ng',
+        fallback: 'matthew@example.com',
+      ),
+      'Matthew Ng',
+    );
+  });
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+cd frontend
+/Users/matthewng/Desktop/flutter/bin/flutter test test/screens/community/community_author_mapper_test.dart
+```
+
+Expected: FAIL to compile — `username` is not a parameter.
+
+- [ ] **Step 3: Add the top rung**
+
+In `community_author_mapper.dart`, add the parameter and the first branch,
+leaving the rest of the function as it is:
+
+```dart
+  static String authorDisplayName({
+    String? username,
+    String? firstName,
+    String? lastName,
+    required String fallback,
+  }) {
+    // The @ marks a handle, never a person, so it appears here and nowhere
+    // further down the ladder.
+    final handle = (username ?? '').trim();
+    if (handle.isNotEmpty) {
+      return '@$handle';
+    }
+    final first = (firstName ?? '').trim();
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+```bash
+cd frontend
+/Users/matthewng/Desktop/flutter/bin/flutter test test/screens/community/community_author_mapper_test.dart
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 5: Pass the handle from all four call sites**
+
+Each caller adds one argument. In `community_post_mapper.dart` around line
+23:
+
+```dart
+    final authorName = authorDisplayName(
+      username: rawPost['author_username']?.toString(),
+      firstName: rawPost['author_first_name']?.toString(),
+      lastName: rawPost['author_last_name']?.toString(),
+      fallback: rawPost['author_email']?.toString() ??
+          rawPost['user_id']?.toString() ??
+          'unknown',
+    );
+```
+
+In `mappers/community_comment_tree_mapper.dart` around line 53, the same
+addition with `comment[...]` in place of `rawPost[...]`. In
+`mappers/community_quote_mapper.dart`, both call sites take
+`username: m['author_username']?.toString(),`.
+
+Then make `PostAuthor.username` the real handle rather than an invented one.
+In `community_post_mapper.dart`:
+
+```dart
+      author: PostAuthor(
+        id: (rawPost['user_id'] ?? '').toString(),
+        displayName: authorName,
+        username: (rawPost['author_username'] ?? '').toString(),
+      ),
+```
+
+- [ ] **Step 6: Delete the invented handle**
+
+`usernameFromEmailOrId` mints a handle from an email or a uuid, which is the
+behaviour this change removes. Delete it from
+`community_author_mapper.dart` and fix whatever stops compiling. Every
+caller either has a real `author_username` now, or should pass an empty
+string.
+
+```bash
+cd frontend
+grep -rn usernameFromEmailOrId lib/ test/
+```
+
+Work through that list; the file compiles clean when it is empty.
+
+- [ ] **Step 7: Stop the reply prefill inventing a mention**
+
+`thread_detail_screen.dart:62` builds `'@${target.author.username} '`. With
+no handle that produced `@user`. Prefill nothing instead:
+
+```dart
+    final handle = target.author.username.trim();
+    final mention = handle.isEmpty ? '' : '@$handle ';
+```
+
+- [ ] **Step 8: Point the Edit Profile username field at its own route**
+
+`users_api.dart` sends `username` inside the profile update; that field no
+longer exists there. Add a method beside it:
+
+```dart
+  Future<String?> setUsername(String? username) async {
+    final response = await _dio.put<Map<String, dynamic>>(
+      '/users/me/username',
+      data: {'username': username},
+    );
+    return response.data?['username'] as String?;
+  }
+```
+
+Remove `username` from the profile-update payload in the same file, and in
+`edit_profile_screen.dart` call `setUsername` when that field changed,
+showing a 409 as "That username is taken".
+
+- [ ] **Step 9: Run everything**
+
+```bash
+cd frontend
+/Users/matthewng/Desktop/flutter/bin/flutter test
+/Users/matthewng/Desktop/flutter/bin/dart analyze lib/ test/
+```
+
+Expected: all pass, "No issues found!". `flutter analyze` exits 64 on this
+machine — a pre-existing toolchain fault; use `dart analyze` and say so.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add frontend/
+git commit -m "feat(community): show a chosen username everywhere"
+```
+
+---
+
+### Task 6: Verify against the running stack, then document
+
+**Files:**
+- Modify: `docs/service-ownership.md`
+- Modify: `docs/database_schema.md` (regenerate)
+
+**Interfaces:**
+- Consumes: Tasks 1-5.
+- Produces: nothing code depends on.
+
+- [ ] **Step 1: Set a username and read it back from the feed**
+
+The stubbed suites cannot prove the handle travels from the settings screen
+to a post. Start the services (`.venv/bin/python backend/run.py --all`),
+then:
+
+```bash
+MAIN=http://localhost:8080/api/v1
+COM=http://localhost:5001/api/v1
+EMAIL="username-probe@example.com"
+
+TOK=$(curl -s -m 15 -X POST "$MAIN/auth/register" -H 'Content-Type: application/json' \
+  -d "{\"email\":\"$EMAIL\",\"password\":\"ProbePass123\",\"first_name\":\"Probe\",\"last_name\":\"User\"}" \
+  | python3 -c "import sys,json;print(json.load(sys.stdin).get('access_token',''))")
+
+echo "set:      $(curl -s -m 15 -X PUT "$MAIN/users/me/username" \
+  -H "Authorization: Bearer $TOK" -H 'Content-Type: application/json' \
+  -d '{"username":"SnowKing"}')"
+
+echo "profile:  $(curl -s -m 15 -H "Authorization: Bearer $TOK" "$MAIN/users/me/profile" \
+  | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('username'))")"
+
+echo "taken:    $(curl -s -m 15 -o /dev/null -w '%{http_code}' -X PUT "$MAIN/users/me/username" \
+  -H "Authorization: Bearer $TOK" -H 'Content-Type: application/json' \
+  -d '{"username":"snowking"}')"
+```
+
+Expected:
+
+```
+set:      {"username":"snowking"}
+profile:  snowking
+taken:    200
+```
+
+`taken: 409` would mean the uniqueness check does not exclude the caller,
+so nobody could ever re-save their own handle. Delete the probe account
+afterwards.
+
+- [ ] **Step 2: Record the rule**
+
+In `docs/service-ownership.md`, under the ownership matrix:
+
+```markdown
+- display identity: `user_info`. A user's chosen `username` is what every
+  surface shows, so it lives beside `is_private` and `country_code` rather
+  than in `profiles`. The rule: `user_info` holds what other services read,
+  `profiles` holds what only the profile screen reads.
+```
+
+- [ ] **Step 3: Regenerate the schema dump**
+
+```bash
+cd /Users/matthewng/Desktop/Snowtrak
+.venv/bin/python scripts/dump_supabase_schema.py
+git diff --stat docs/database_schema.md
+```
+
+Expect `user_info.username` added and `profiles.full_name` /
+`profiles.username` gone, alongside the 019-021 changes the dump still
+predates. Read anything else in that diff before committing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/
+git commit -m "docs(profiles): record where the display identity lives"
+```
+
+---
+
+## What this plan deliberately leaves out
+
+Avatars in the feed. Migration 022 makes `upload_avatar` persist its URL, so
+the profile screen shows a real avatar for the first time, but the community
+API returns no avatar field at all and adding one is its own change.
+
+`profiles.push_token`, which duplicates the `device_tokens` table and is read
+by nothing. It belongs with the push work in #41.

--- a/docs/superpowers/specs/2026-09-04-profiles-repair-design.md
+++ b/docs/superpowers/specs/2026-09-04-profiles-repair-design.md
@@ -1,0 +1,231 @@
+# Profiles Repair and Username Identity Design
+
+Status: approved, not yet implemented.
+Date: 2026-09-04.
+Issue: [#43](https://github.com/Syntraksoftware/Snowtrak/issues/43).
+
+## Summary
+
+`profiles` can be written again, and a user's chosen username becomes the
+name everyone sees.
+
+Two problems that look separate share a cause. `profiles` is unwritable, so
+profile edits fail and avatars are lost. And a username, once it can be
+saved, would still not appear anywhere, because every feed reads
+`user_info`. Fixing the first without the second ships a setting that
+visibly does nothing.
+
+## The starting position
+
+Confirmed against the live database on 2026-09-04, by inserting a real
+`user_info` id into `profiles`:
+
+```text
+insert or update on table "profiles" violates foreign key constraint
+"profiles_id_fkey"
+Key (id)=(1b85344b-...) is not present in table "users".
+```
+
+`profiles.id` references Supabase auth's `users`. Registration writes
+`user_info`. So `create_profile` fails with 23503 every time and the table
+has never held a row:
+
+```text
+user_info    41 rows
+profiles      0 rows
+```
+
+`main-backend` already works around this on the read path, rendering a
+profile from `user_info` in `_profile_from_user_info`. Only writes are
+broken — and they are broken for everyone.
+
+## Who reads what today
+
+This is the fact that shapes the design.
+
+| Table | Read by |
+|---|---|
+| `profiles` | one file, `main-backend/app/core/supabase/profiles.py`, four call sites, all serving the profile screen |
+| `user_info` | ten files across all three services — every feed, author line, leaderboard row and duel card |
+
+Every displayed name in the app already comes from `user_info`. Repairing
+`profiles` as it stands would put `full_name` back in play and create a
+second source for the same fact, which drifts silently: the profile screen
+would show one name and the feed another.
+
+## Decisions
+
+**One rule decides where a column lives.**
+
+> `user_info` holds what other services read. `profiles` holds what only the
+> profile screen reads.
+
+`is_private` and `country_code` already follow it. Applying it:
+
+| Column | Lives in | Why |
+|---|---|---|
+| `first_name`, `last_name` | `user_info` | feeds, leaderboards and duels read them |
+| `username` | **moves to `user_info`** | it becomes the displayed identity, and it is what an `@mention` resolves to |
+| `bio`, `avatar_url`, `ski_level`, `home` | `profiles` | only the profile screen reads them |
+| `full_name` | **dropped** | derived from `first_name` and `last_name`; storing it is the second source |
+
+**A chosen username is the identity, everywhere.** If a user sets
+`snowking`, every surface shows `@snowking` — feed, thread, reply mention,
+leaderboard row, duel card. The real name stays on their own settings
+screen. This is also the privacy-safer reading: somebody who picks a handle
+does not leak their real name anywhere.
+
+**One display ladder, in one place.**
+
+```text
+@username        when the user has set one
+First Last       when they have not
+email handle     when they have neither
+Skier            when the author is gone entirely
+```
+
+The `@` appears only on the first rung. A user with no username shows
+`Matthew Ng`, not `@Matthew Ng`.
+
+**Usernames are not generated.** The backfill writes ids and nothing else,
+leaving `username` null for all 41 users. Deriving handles from email
+addresses would mint a handle nobody chose, collide across domains, and leak
+real names into a field whose purpose is to hide them. The ladder already
+handles null.
+
+**`profiles.id` is re-pointed rather than the table being dissolved.** The
+alternative — folding all six columns into `user_info` and dropping
+`profiles` — ends with one table and no ambiguity, but moves five columns
+that nothing outside the profile screen wants and rewrites the profile
+route. Re-pointing keeps the split, and the split is defensible once the
+rule above decides it: `user_info` is identity, `profiles` is presentation.
+
+## Migration 022
+
+```sql
+-- profiles.id references Supabase auth's users; registration writes
+-- user_info. Re-point it at the table that actually holds the rows.
+alter table profiles drop constraint profiles_id_fkey;
+alter table profiles add constraint profiles_id_fkey
+  foreign key (id) references user_info(id) on delete cascade;
+
+-- One profile per existing user. Ids only: see "Usernames are not
+-- generated" above.
+insert into profiles (id)
+select id from user_info
+on conflict (id) do nothing;
+
+-- The second source for a name, removed before it can be written to.
+alter table profiles drop column full_name;
+
+-- The displayed identity moves to where every service already reads.
+alter table user_info add column if not exists username text;
+create unique index if not exists user_info_username_key
+  on user_info (lower(username)) where username is not null;
+alter table profiles drop column username;
+```
+
+The unique index is on `lower(username)` so `SnowKing` and `snowking` cannot
+both exist, and partial so the 41 null usernames do not collide with each
+other.
+
+**Numbering.** The account deletion plan
+(`docs/superpowers/plans/2026-09-04-account-deletion.md`) also claims 022.
+That change lands second, so its migration becomes **023**, and it gains one
+line: `profiles` now holds rows and must cascade with its user, which the
+re-pointed foreign key above already does.
+
+## Backend
+
+**Reads.** Every place that selects a name adds `username` to its select and
+resolves the ladder. The selects are already in one place per service:
+
+- `community-backend`: the embedded `user_info!<fk>(email, first_name,
+  last_name)` selects in `community_post_read_operations.py` and
+  `community_comment_read_operations.py`
+- `activity-backend`: `_USER_COLUMNS` in `leaderboard_operations.py` and the
+  select in `DuelOperations.players`
+- `main-backend`: `posts.py` and `comments.py`
+
+**The ladder is resolved twice, once per language, and that is deliberate.**
+The two halves of the app already split this way and unifying them would be
+a bigger change than this one:
+
+- **Server-side**, for surfaces that already send a finished name:
+  `leaderboard_operations.display_fields` and `DuelOperations.players`. The
+  ladder becomes one function in `backend/shared/`, since both call it and a
+  second copy would drift.
+- **Client-side**, for the community feed, which sends raw author fields
+  (`author_first_name`, `author_last_name`, `author_email`) and resolves them
+  in `CommunityAuthorMapper.authorDisplayName`. It gains `author_username`
+  alongside the others. Changing that payload to send a finished name instead
+  is a two-sided break for every post, comment and quote, and it is not what
+  this change is about.
+
+Two implementations of one rule is a real cost, so both are tested against
+the same four cases, and the rule is stated once — here — rather than in
+either of them.
+
+**Writes.** `update_profile` stops accepting `full_name` and `username`.
+Username moves to its own route, `PUT /api/v1/users/me/username`, next to
+`/me/privacy` and `/me/country` — the two settings that already live on
+`user_info`. It returns 409 on a taken handle, and `username_exists` moves
+to query `user_info`.
+
+**Validation.** A username is 3 to 20 characters, `[a-z0-9_]` after
+lower-casing, and is stored lower-cased. Rejecting mixed case at the edge
+rather than preserving it keeps the mention parser simple: `@snowking` has
+exactly one spelling.
+
+## Frontend
+
+`CommunityAuthorMapper.authorDisplayName` gains the top rung and keeps the
+rest. Every community author name already resolves through it.
+
+`usernameFromEmailOrId` is deleted. It invents a handle from an email or a
+uuid, which is the behaviour this change exists to remove; `PostAuthor.
+username` comes from the API or is empty.
+
+`thread_detail_screen.dart:62` builds a reply mention as
+`'@${target.author.username} '`. With a real username that becomes correct;
+with none it must not produce `@user`, so the reply prefills with no mention
+rather than a wrong one.
+
+The Edit Profile screen keeps its username field and points it at the new
+route, showing the 409 as "That username is taken".
+
+Avatars: repairing `profiles` makes `upload_avatar` persist its URL, so the
+profile screen shows a real avatar for the first time. The feed still shows
+initials — the community API does not return an avatar at all, and adding
+one is a separate change, not a consequence of this one.
+
+## Testing
+
+Backend:
+
+- The shared ladder: username wins; then first and last name; then the email
+  handle; then the placeholder. A null username does not render `@`.
+- `PUT /me/username` returns 409 for a handle taken by another user,
+  case-insensitively, and 200 when the same user re-submits their own.
+- Rejected shapes: two characters, twenty-one characters, a space, a dot.
+- A profile update no longer accepts `full_name` and does not silently drop
+  it — the field is gone from the schema, so an unknown key is ignored by
+  Pydantic as it is everywhere else.
+
+Frontend:
+
+- `authorDisplayName` with a username returns `@snowking`; with a name and
+  no username returns `Matthew Ng` with no `@`.
+- A reply to an author with no username prefills empty rather than `@user`.
+
+Verification against the running stack, which the stubbed suites cannot
+reach: set a username, then read a post by that user from the community feed
+and confirm the author line changed.
+
+## Out of scope
+
+- Avatars in the feed. The community API returns none today.
+- `profiles.push_token`, which duplicates the `device_tokens` table and is
+  read by nothing. Removing it belongs with the push work in #41.
+- Backfilling or suggesting usernames for the 41 existing users.
+- Any change to how `first_name` and `last_name` are collected.

--- a/frontend/lib/features/profile/data/profile_repository.dart
+++ b/frontend/lib/features/profile/data/profile_repository.dart
@@ -23,7 +23,6 @@ class ProfileRepository {
 
   Future<Profile> updateProfile({
     String? fullName,
-    String? username,
     String? bio,
     String? avatarUrl,
     String? pushToken,
@@ -32,13 +31,16 @@ class ProfileRepository {
   }) {
     return _api.updateProfile(
       fullName: fullName,
-      username: username,
       bio: bio,
       avatarUrl: avatarUrl,
       pushToken: pushToken,
       skiLevel: skiLevel,
       home: home,
     );
+  }
+
+  Future<String?> setUsername(String? username) {
+    return _api.setUsername(username);
   }
 
   Future<Profile> getProfileById(String userId) {

--- a/frontend/lib/features/profile/data/profile_repository.dart
+++ b/frontend/lib/features/profile/data/profile_repository.dart
@@ -22,7 +22,6 @@ class ProfileRepository {
   }
 
   Future<Profile> updateProfile({
-    String? fullName,
     String? bio,
     String? avatarUrl,
     String? pushToken,
@@ -30,7 +29,6 @@ class ProfileRepository {
     String? home,
   }) {
     return _api.updateProfile(
-      fullName: fullName,
       bio: bio,
       avatarUrl: avatarUrl,
       pushToken: pushToken,

--- a/frontend/lib/providers/notification_provider.dart
+++ b/frontend/lib/providers/notification_provider.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:snowtrak/core/errors/app_result.dart';
 import 'package:snowtrak/models/duel.dart';
 import 'package:snowtrak/models/notification.dart';
+import 'package:snowtrak/screens/community/mappers/community_author_mapper.dart';
 import 'package:snowtrak/services/duel_service.dart';
 import 'package:snowtrak/services/follow_service.dart';
 
@@ -160,7 +161,12 @@ class NotificationProvider extends ChangeNotifier {
   /// and survives the list being rebuilt.
   static AppNotification _followRequestNotification(Map<String, dynamic> row) {
     final userId = (row['user_id'] as String?)?.trim() ?? '';
-    final name = _displayName(row);
+    final name = CommunityAuthorMapper.authorDisplayName(
+      username: row['username'] as String?,
+      firstName: row['first_name'] as String?,
+      lastName: row['last_name'] as String?,
+      fallback: row['email'] as String? ?? '',
+    );
     final createdAt = DateTime.tryParse(row['created_at'] as String? ?? '');
     return AppNotification(
       id: 'follow_request:$userId',
@@ -190,15 +196,5 @@ class NotificationProvider extends ChangeNotifier {
       senderName: name,
       metadata: {'duel_id': duel.id},
     );
-  }
-
-  static String _displayName(Map<String, dynamic> row) {
-    final first = (row['first_name'] as String?)?.trim() ?? '';
-    final last = (row['last_name'] as String?)?.trim() ?? '';
-    final full = [first, last].where((s) => s.isNotEmpty).join(' ');
-    if (full.isNotEmpty) return full;
-    final email = (row['email'] as String?)?.trim() ?? '';
-    if (email.contains('@')) return email.split('@').first;
-    return 'Someone';
   }
 }

--- a/frontend/lib/screens/community/community_post_mapper.dart
+++ b/frontend/lib/screens/community/community_post_mapper.dart
@@ -21,6 +21,7 @@ class CommunityPostMapper {
         DateTime.tryParse((rawPost['created_at'] ?? '').toString()) ??
             DateTime.now();
     final authorName = authorDisplayName(
+      username: rawPost['author_username']?.toString(),
       firstName: rawPost['author_first_name']?.toString(),
       lastName: rawPost['author_last_name']?.toString(),
       fallback: rawPost['author_email']?.toString() ??
@@ -58,10 +59,7 @@ class CommunityPostMapper {
       author: PostAuthor(
         id: (rawPost['user_id'] ?? '').toString(),
         displayName: authorName,
-        username: usernameFromEmailOrId(
-          rawPost['author_email']?.toString(),
-          rawPost['user_id']?.toString(),
-        ),
+        username: (rawPost['author_username'] ?? '').toString(),
       ),
       text: content.isNotEmpty
           ? content
@@ -129,19 +127,17 @@ class CommunityPostMapper {
   }
 
   static String authorDisplayName({
+    String? username,
     String? firstName,
     String? lastName,
     required String fallback,
   }) {
     return CommunityAuthorMapper.authorDisplayName(
+      username: username,
       firstName: firstName,
       lastName: lastName,
       fallback: fallback,
     );
-  }
-
-  static String usernameFromEmailOrId(String? email, String? fallbackId) {
-    return CommunityAuthorMapper.usernameFromEmailOrId(email, fallbackId);
   }
 
   static String timestampLabel(DateTime createdAt) {

--- a/frontend/lib/screens/community/mappers/community_author_mapper.dart
+++ b/frontend/lib/screens/community/mappers/community_author_mapper.dart
@@ -1,45 +1,40 @@
 class CommunityAuthorMapper {
   CommunityAuthorMapper._();
 
-  static bool looksLikeUuid(String s) {
-    final t = s.trim();
-    return RegExp(
-      r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$',
-    ).hasMatch(t);
-  }
-
-  static String usernameFromEmailOrId(String? email, String? fallbackId) {
-    final e = (email ?? '').trim();
-    if (e.contains('@')) {
-      return e.split('@').first;
-    }
-    final id = (fallbackId ?? '').trim();
-    if (id.isEmpty) {
-      return 'user';
-    }
-    if (looksLikeUuid(id)) {
-      return 'member';
-    }
-    return id.length > 12 ? id.substring(0, 12) : id;
-  }
-
+  /// The name to show for one author.
+  ///
+  /// Mirrors `backend/shared/display_name.py`'s `display_name` case for
+  /// case: a chosen handle wins and carries the `@`, then the full name,
+  /// then the fallback's email handle, then `fallback` itself when it
+  /// carries no `@` to split on. The community feed has no `deleted` bit to
+  /// check here -- a gone author never reaches this mapper with a row to
+  /// map in the first place.
   static String authorDisplayName({
+    String? username,
     String? firstName,
     String? lastName,
     required String fallback,
   }) {
+    // The @ marks a handle, never a person, so it appears here and nowhere
+    // further down the ladder.
+    final handle = (username ?? '').trim();
+    if (handle.isNotEmpty) {
+      return '@$handle';
+    }
     final first = (firstName ?? '').trim();
     final last = (lastName ?? '').trim();
-    if (first.isNotEmpty || last.isNotEmpty) {
-      return '$first $last'.trim();
+    final full = [first, last].where((part) => part.isNotEmpty).join(' ');
+    if (full.isNotEmpty) {
+      return full;
     }
     final fb = fallback.trim();
-    if (looksLikeUuid(fb)) {
-      return 'Member';
-    }
     if (fb.contains('@')) {
       return fb.split('@').first;
     }
-    return usernameFromEmailOrId(null, fb);
+    // Matches display_name.py's final rung exactly: a fallback with no `@`
+    // to split on -- blank, or a raw id with nothing else to show -- reads
+    // as "nothing to name this author by", same as the Python side's
+    // deleted-author case.
+    return 'Skier';
   }
 }

--- a/frontend/lib/screens/community/mappers/community_comment_tree_mapper.dart
+++ b/frontend/lib/screens/community/mappers/community_comment_tree_mapper.dart
@@ -51,6 +51,7 @@ class CommunityCommentTreeMapper {
     final createdAt =
         DateTime.tryParse((comment['created_at'] ?? '').toString()) ?? DateTime.now();
     final authorName = CommunityAuthorMapper.authorDisplayName(
+      username: comment['author_username']?.toString(),
       firstName: comment['author_first_name']?.toString(),
       lastName: comment['author_last_name']?.toString(),
       fallback: comment['author_email']?.toString() ??
@@ -65,10 +66,7 @@ class CommunityCommentTreeMapper {
       author: PostAuthor(
         id: (comment['user_id'] ?? '').toString(),
         displayName: authorName,
-        username: CommunityAuthorMapper.usernameFromEmailOrId(
-          comment['author_email']?.toString(),
-          comment['user_id']?.toString(),
-        ),
+        username: (comment['author_username'] ?? '').toString(),
       ),
       text: (comment['content'] ?? '').toString(),
       subthreadId: threadSubthreadId,

--- a/frontend/lib/screens/community/mappers/community_quote_mapper.dart
+++ b/frontend/lib/screens/community/mappers/community_quote_mapper.dart
@@ -15,6 +15,7 @@ class CommunityQuoteMapper {
     final titleRaw = m['title']?.toString();
     final body = (m['content'] ?? '').toString();
     final authorName = CommunityAuthorMapper.authorDisplayName(
+      username: m['author_username']?.toString(),
       firstName: m['author_first_name']?.toString(),
       lastName: m['author_last_name']?.toString(),
       fallback: m['author_email']?.toString() ?? m['user_id']?.toString() ?? 'unknown',
@@ -24,10 +25,7 @@ class CommunityQuoteMapper {
       author: PostAuthor(
         id: (m['user_id'] ?? '').toString(),
         displayName: authorName,
-        username: CommunityAuthorMapper.usernameFromEmailOrId(
-          m['author_email']?.toString(),
-          m['user_id']?.toString(),
-        ),
+        username: (m['author_username'] ?? '').toString(),
       ),
       text: body.isNotEmpty ? body : (titleRaw ?? '').toString(),
       topic: CommunityPostFieldParsers.topicFromStructuredTitle(titleRaw),
@@ -53,6 +51,7 @@ class CommunityQuoteMapper {
         DateTime.tryParse((m['created_at'] ?? '').toString()) ?? DateTime.now();
     final body = (m['content'] ?? '').toString();
     final authorName = CommunityAuthorMapper.authorDisplayName(
+      username: m['author_username']?.toString(),
       firstName: m['author_first_name']?.toString(),
       lastName: m['author_last_name']?.toString(),
       fallback: m['author_email']?.toString() ?? m['user_id']?.toString() ?? 'unknown',
@@ -62,10 +61,7 @@ class CommunityQuoteMapper {
       author: PostAuthor(
         id: (m['user_id'] ?? '').toString(),
         displayName: authorName,
-        username: CommunityAuthorMapper.usernameFromEmailOrId(
-          m['author_email']?.toString(),
-          m['user_id']?.toString(),
-        ),
+        username: (m['author_username'] ?? '').toString(),
       ),
       text: body,
       isComment: true,

--- a/frontend/lib/screens/community/thread_detail_screen.dart
+++ b/frontend/lib/screens/community/thread_detail_screen.dart
@@ -59,7 +59,8 @@ class _ThreadDetailScreenState extends State<ThreadDetailScreen> {
   }
 
   void _handleReplyTo(Post target) {
-    final mention = '@${target.author.username} ';
+    final handle = target.author.username.trim();
+    final mention = handle.isEmpty ? '' : '@$handle ';
     final current = _replyController.text;
     if (!current.startsWith(mention)) {
       _replyController.text = '$mention$current'.trimRight();
@@ -301,6 +302,14 @@ class _ThreadOriginalPostCard extends StatelessWidget {
     final initial = post.author.displayName.isNotEmpty
         ? post.author.displayName[0].toUpperCase()
         : 'U';
+    final topic = (post.topic ?? '').trim();
+    final handle = post.author.username.trim();
+    // Falls to an empty label rather than a bare "@" when the author has no
+    // topic and no chosen handle -- the common case now that a real, often
+    // empty, username replaces the always-populated invented one.
+    final secondaryLine = topic.isNotEmpty
+        ? topic
+        : (handle.isNotEmpty ? '@$handle' : '');
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
       child: Column(
@@ -350,9 +359,7 @@ class _ThreadOriginalPostCard extends StatelessWidget {
                           ),
                           Flexible(
                             child: Text(
-                              (post.topic ?? '').trim().isNotEmpty
-                                  ? post.topic!.trim()
-                                  : '@${post.author.username}',
+                              secondaryLine,
                               style: TextStyle(
                                 fontSize: 14,
                                 color: context.colors.textSecondary,

--- a/frontend/lib/screens/community/thread_draft_builders.dart
+++ b/frontend/lib/screens/community/thread_draft_builders.dart
@@ -5,7 +5,7 @@ import 'package:snowtrak/screens/community/mappers/community_author_mapper.dart'
 class CommunityDraftBuilders {
   CommunityDraftBuilders._();
 
-  // TODO(#43): a chosen handle cannot reach an optimistic draft -- `User`
+  // TODO(#53): a chosen handle cannot reach an optimistic draft -- `User`
   // has no username field, so a draft shows the name rung and the
   // refreshed post shows @handle. Fix needs `username` on the auth
   // payload.

--- a/frontend/lib/screens/community/thread_draft_builders.dart
+++ b/frontend/lib/screens/community/thread_draft_builders.dart
@@ -1,17 +1,25 @@
 import 'package:snowtrak/models/post.dart';
 import 'package:snowtrak/models/user.dart';
+import 'package:snowtrak/screens/community/mappers/community_author_mapper.dart';
 
 class CommunityDraftBuilders {
   CommunityDraftBuilders._();
 
+  // TODO(#43): a chosen handle cannot reach an optimistic draft -- `User`
+  // has no username field, so a draft shows the name rung and the
+  // refreshed post shows @handle. Fix needs `username` on the auth
+  // payload.
   static PostAuthor buildAuthor(User user) {
-    final displayName = user.firstName != null && user.lastName != null
-        ? '${user.firstName} ${user.lastName}'
-        : user.email.split('@')[0];
+    final displayName = CommunityAuthorMapper.authorDisplayName(
+      username: null,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      fallback: user.email,
+    );
     return PostAuthor(
       id: user.id,
       displayName: displayName,
-      username: user.email.split('@')[0],
+      username: '',
       avatarUrl: null,
     );
   }

--- a/frontend/lib/screens/community/widgets/quoted_post_embed.dart
+++ b/frontend/lib/screens/community/widgets/quoted_post_embed.dart
@@ -39,7 +39,7 @@ class QuotedPostEmbed extends StatelessWidget {
               ),
               const SizedBox(width: 8),
               Text(
-                post.author.username,
+                post.author.displayName,
                 style: SnowtrakTypography.labelMedium.copyWith(
                   fontWeight: FontWeight.w700,
                   color: context.colors.textPrimary,

--- a/frontend/lib/screens/profile/edit_profile_screen.dart
+++ b/frontend/lib/screens/profile/edit_profile_screen.dart
@@ -27,6 +27,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
   bool _isSaving = false;
   String? _error;
   String _loadedUsername = '';
+  String _loadedFullName = '';
 
   @override
   void initState() {
@@ -70,7 +71,8 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
           final profile = value;
           if (!mounted) return;
 
-          _fullNameController.text = profile.fullName ?? '';
+          _loadedFullName = profile.fullName ?? '';
+          _fullNameController.text = _loadedFullName;
           _loadedUsername = profile.username ?? '';
           _usernameController.text = _loadedUsername;
           _bioController.text = profile.bio ?? '';
@@ -111,7 +113,6 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
       }
 
       final saveResult = await _profileService.updateProfile(
-        fullName: _fullNameController.text.trim(),
         bio: _bioController.text.trim(),
         skiLevel: _skiLevelController.text.trim(),
         home: _homeController.text.trim(),
@@ -129,6 +130,34 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
           return;
         case AppSuccess():
           break;
+      }
+
+      // The name lives on user_info, not on profiles, so it goes to
+      // PUT /users/me. Sending it as `full_name` on the profile update was
+      // accepted and dropped: the field looked saved and never was.
+      final newFullName = _fullNameController.text.trim();
+      if (newFullName != _loadedFullName) {
+        final parts = newFullName.split(' ');
+        final nameResult = await _profileService.updateUserProfile(
+          firstName: parts.first,
+          // Everything after the first space, so "Anne Marie de Vries" keeps
+          // its tail. Empty for a one-word name, which clears the last name.
+          lastName: parts.skip(1).join(' '),
+        );
+
+        if (!mounted) {
+          return;
+        }
+
+        switch (nameResult) {
+          case AppFailure(:final error):
+            setState(() {
+              _error = error.userMessage;
+            });
+            return;
+          case AppSuccess():
+            _loadedFullName = newFullName;
+        }
       }
 
       final newUsername = _usernameController.text.trim();

--- a/frontend/lib/screens/profile/edit_profile_screen.dart
+++ b/frontend/lib/screens/profile/edit_profile_screen.dart
@@ -26,6 +26,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
   bool _isLoading = true;
   bool _isSaving = false;
   String? _error;
+  String _loadedUsername = '';
 
   @override
   void initState() {
@@ -70,7 +71,8 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
           if (!mounted) return;
 
           _fullNameController.text = profile.fullName ?? '';
-          _usernameController.text = profile.username ?? '';
+          _loadedUsername = profile.username ?? '';
+          _usernameController.text = _loadedUsername;
           _bioController.text = profile.bio ?? '';
           _skiLevelController.text = profile.skiLevel ?? '';
           _homeController.text = profile.home ?? '';
@@ -110,15 +112,17 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
 
       final saveResult = await _profileService.updateProfile(
         fullName: _fullNameController.text.trim(),
-        username: _usernameController.text.trim(),
         bio: _bioController.text.trim(),
         skiLevel: _skiLevelController.text.trim(),
         home: _homeController.text.trim(),
       );
 
+      if (!mounted) {
+        return;
+      }
+
       switch (saveResult) {
         case AppFailure(:final error):
-          if (!mounted) return;
           setState(() {
             _error = error.userMessage;
           });
@@ -127,8 +131,25 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
           break;
       }
 
-      if (!mounted) {
-        return;
+      final newUsername = _usernameController.text.trim();
+      if (newUsername != _loadedUsername) {
+        final usernameResult = await _profileService.setUsername(
+          newUsername.isEmpty ? null : newUsername,
+        );
+
+        if (!mounted) {
+          return;
+        }
+
+        switch (usernameResult) {
+          case AppFailure(:final error):
+            setState(() {
+              _error = error.userMessage;
+            });
+            return;
+          case AppSuccess(:final value):
+            _loadedUsername = value ?? '';
+        }
       }
 
       ScaffoldMessenger.of(context).showSnackBar(

--- a/frontend/lib/screens/profile/follow_requests_screen.dart
+++ b/frontend/lib/screens/profile/follow_requests_screen.dart
@@ -4,6 +4,7 @@ import 'package:snowtrak/core/di/service_locator.dart';
 import 'package:snowtrak/core/errors/app_error.dart';
 import 'package:snowtrak/core/errors/app_result.dart';
 import 'package:snowtrak/core/theme.dart';
+import 'package:snowtrak/screens/community/mappers/community_author_mapper.dart';
 import 'package:snowtrak/screens/profile/widgets/profile_layout_primitives.dart';
 import 'package:snowtrak/services/follow_service.dart';
 import 'package:snowtrak/ui/st/st.dart';
@@ -320,23 +321,23 @@ class _RequestRow extends StatelessWidget {
   final VoidCallback onApprove;
   final VoidCallback onDeny;
 
+  /// The one display ladder, same as every other author line.
+  ///
+  /// There is no second `@handle` line under it: the ladder already puts the
+  /// `@` on a chosen handle, and the email local part that used to fill that
+  /// line was a handle nobody picked.
   String get _name {
-    final first = (request['first_name'] as String?)?.trim() ?? '';
-    final last = (request['last_name'] as String?)?.trim() ?? '';
-    final full = [first, last].where((s) => s.isNotEmpty).join(' ');
-    return full.isNotEmpty ? full : 'User';
-  }
-
-  String get _handle {
-    final email = (request['email'] as String?)?.trim() ?? '';
-    if (!email.contains('@')) return '';
-    return '@${email.split('@').first}';
+    return CommunityAuthorMapper.authorDisplayName(
+      username: request['username'] as String?,
+      firstName: request['first_name'] as String?,
+      lastName: request['last_name'] as String?,
+      fallback: request['email'] as String? ?? '',
+    );
   }
 
   @override
   Widget build(BuildContext context) {
     final name = _name;
-    final handle = _handle;
 
     return Padding(
       padding: const EdgeInsets.symmetric(
@@ -367,12 +368,6 @@ class _RequestRow extends StatelessWidget {
                     color: context.colors.textPrimary,
                   ),
                 ),
-                if (handle.isNotEmpty)
-                  Text(
-                    handle,
-                    style: SnowtrakTypography.bodySmall
-                        .copyWith(color: context.colors.textSecondary),
-                  ),
               ],
             ),
           ),

--- a/frontend/lib/services/apis/users_api.dart
+++ b/frontend/lib/services/apis/users_api.dart
@@ -27,8 +27,12 @@ class UsersApi {
     return Profile.fromJson(response.data);
   }
 
+  /// Updates the presentation fields `profiles` owns.
+  ///
+  /// No `full_name`: migration 022 dropped that column, so the field was
+  /// accepted, dropped by Pydantic and answered 200 -- a save that did
+  /// nothing. The name is written through [updateUserProfile].
   Future<Profile> updateProfile({
-    String? fullName,
     String? bio,
     String? avatarUrl,
     String? pushToken,
@@ -36,7 +40,6 @@ class UsersApi {
     String? home,
   }) async {
     final response = await _dio.put('/users/me/profile', data: {
-      if (fullName != null) 'full_name': fullName,
       if (bio != null) 'bio': bio,
       if (avatarUrl != null) 'avatar_url': avatarUrl,
       if (pushToken != null) 'push_token': pushToken,

--- a/frontend/lib/services/apis/users_api.dart
+++ b/frontend/lib/services/apis/users_api.dart
@@ -29,7 +29,6 @@ class UsersApi {
 
   Future<Profile> updateProfile({
     String? fullName,
-    String? username,
     String? bio,
     String? avatarUrl,
     String? pushToken,
@@ -38,7 +37,6 @@ class UsersApi {
   }) async {
     final response = await _dio.put('/users/me/profile', data: {
       if (fullName != null) 'full_name': fullName,
-      if (username != null) 'username': username,
       if (bio != null) 'bio': bio,
       if (avatarUrl != null) 'avatar_url': avatarUrl,
       if (pushToken != null) 'push_token': pushToken,
@@ -46,6 +44,17 @@ class UsersApi {
       if (home != null) 'home': home,
     });
     return Profile.fromJson(response.data);
+  }
+
+  /// Sets or clears the caller's chosen handle via its own endpoint --
+  /// separate from [updateProfile] because a taken handle (409) is a
+  /// different failure mode than the rest of the profile fields.
+  Future<String?> setUsername(String? username) async {
+    final response = await _dio.put<Map<String, dynamic>>(
+      '/users/me/username',
+      data: {'username': username},
+    );
+    return response.data?['username'] as String?;
   }
 
   Future<Profile> getProfileById(String userId) async {

--- a/frontend/lib/services/profile_service.dart
+++ b/frontend/lib/services/profile_service.dart
@@ -32,7 +32,6 @@ class ProfileService {
   }
 
   Future<AppResult<Profile>> updateProfile({
-    String? fullName,
     String? bio,
     String? avatarUrl,
     String? pushToken,
@@ -40,7 +39,6 @@ class ProfileService {
     String? home,
   }) {
     return _run(() => _profileRepository.updateProfile(
-          fullName: fullName,
           bio: bio,
           avatarUrl: avatarUrl,
           pushToken: pushToken,

--- a/frontend/lib/services/profile_service.dart
+++ b/frontend/lib/services/profile_service.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:dio/dio.dart';
 import 'package:snowtrak/core/errors/app_error.dart';
 import 'package:snowtrak/core/errors/app_result.dart';
 import 'package:snowtrak/features/profile/data/profile_repository.dart';
@@ -32,7 +33,6 @@ class ProfileService {
 
   Future<AppResult<Profile>> updateProfile({
     String? fullName,
-    String? username,
     String? bio,
     String? avatarUrl,
     String? pushToken,
@@ -41,13 +41,37 @@ class ProfileService {
   }) {
     return _run(() => _profileRepository.updateProfile(
           fullName: fullName,
-          username: username,
           bio: bio,
           avatarUrl: avatarUrl,
           pushToken: pushToken,
           skiLevel: skiLevel,
           home: home,
         ));
+  }
+
+  /// Sets or clears the caller's chosen handle.
+  ///
+  /// Catches here, not in [_run], because a taken handle needs its own
+  /// user-facing message rather than the generic 4xx copy `AppError.from`
+  /// gives every other failure -- the same shape `AuthService.register`
+  /// uses for its own 409.
+  Future<AppResult<String?>> setUsername(String? username) async {
+    try {
+      return AppSuccess(await _profileRepository.setUsername(username));
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 409) {
+        return AppFailure(
+          AppError(
+            userMessage: 'That username is taken',
+            cause: e,
+            retryable: false,
+          ),
+        );
+      }
+      return AppFailure(AppError.from(e));
+    } catch (e, st) {
+      return AppFailure(AppError.from(e, st));
+    }
   }
 
   Future<AppResult<Profile>> getProfileById(String userId) {

--- a/frontend/lib/widgets/composer_widget.dart
+++ b/frontend/lib/widgets/composer_widget.dart
@@ -103,7 +103,7 @@ class _ComposerWidgetState extends State<ComposerWidget> {
                     // The `@handle` line under this one is gone: the only
                     // handle available here was the email local part, which
                     // is a handle nobody chose.
-                    // TODO(#43): show the real one once `User` carries a
+                    // TODO(#53): show the real one once `User` carries a
                     // username -- that needs the auth payload to send it.
                     Text(
                       CommunityAuthorMapper.authorDisplayName(

--- a/frontend/lib/widgets/composer_widget.dart
+++ b/frontend/lib/widgets/composer_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:snowtrak/core/theme.dart';
 import 'package:provider/provider.dart';
 import 'package:snowtrak/providers/auth_provider.dart';
+import 'package:snowtrak/screens/community/mappers/community_author_mapper.dart';
 
 class ComposerWidget extends StatefulWidget {
   final Function(String text) onPost;
@@ -99,24 +100,23 @@ class _ComposerWidgetState extends State<ComposerWidget> {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
+                    // The `@handle` line under this one is gone: the only
+                    // handle available here was the email local part, which
+                    // is a handle nobody chose.
+                    // TODO(#43): show the real one once `User` carries a
+                    // username -- that needs the auth payload to send it.
                     Text(
-                      user?.firstName != null && user?.lastName != null
-                          ? '${user!.firstName} ${user.lastName}'
-                          : (user?.email ?? 'User').split('@')[0],
+                      CommunityAuthorMapper.authorDisplayName(
+                        firstName: user?.firstName,
+                        lastName: user?.lastName,
+                        fallback: user?.email ?? '',
+                      ),
                       style: TextStyle(
                         fontSize: 15,
                         fontWeight: FontWeight.w600,
                         color: context.colors.textPrimary,
                       ),
                     ),
-                    if (user != null && user.email.isNotEmpty)
-                      Text(
-                        '@${user.email.split('@')[0]}',
-                        style: TextStyle(
-                          fontSize: 13,
-                          color: context.colors.textSecondary,
-                        ),
-                      ),
                   ],
                 ),
               ),

--- a/frontend/lib/widgets/message_card.dart
+++ b/frontend/lib/widgets/message_card.dart
@@ -376,7 +376,7 @@ class _ThreadsMetaRow extends StatelessWidget {
             children: [
               Flexible(
                 child: Text(
-                  post.author.username,
+                  post.author.displayName,
                   style: (compact
                           ? SnowtrakTypography.labelMedium
                           : SnowtrakTypography.labelLarge)

--- a/frontend/lib/widgets/profile_header.dart
+++ b/frontend/lib/widgets/profile_header.dart
@@ -8,6 +8,7 @@ import 'package:snowtrak/core/errors/app_result.dart';
 import 'package:snowtrak/core/theme.dart';
 import 'package:snowtrak/models/profile.dart';
 import 'package:snowtrak/providers/auth_provider.dart';
+import 'package:snowtrak/screens/community/mappers/community_author_mapper.dart';
 import 'package:snowtrak/screens/profile/follow_requests_screen.dart';
 import 'package:snowtrak/widgets/follow_button.dart';
 import 'package:snowtrak/models/follow_stats.dart';
@@ -163,11 +164,16 @@ class _ProfileHeaderState extends State<ProfileHeader> {
     }
 
     final fallbackName = isOwnProfile && authUser != null
-        ? authUser.fullName
+        ? CommunityAuthorMapper.authorDisplayName(
+            firstName: authUser.firstName,
+            lastName: authUser.lastName,
+            fallback: authUser.email,
+          )
         : widget.fallbackName ?? 'User';
-    final fallbackUsername = isOwnProfile && authUser != null
-        ? authUser.email.split('@').first
-        : widget.fallbackUsername ?? '';
+    // No handle invented from the email local part: an `@` marks a chosen
+    // handle and never a person. Blank until the profile itself arrives with
+    // the real one, which is the only place it exists.
+    final fallbackUsername = widget.fallbackUsername ?? '';
 
     return _withError(
       _buildHeader(

--- a/frontend/test/screens/community/community_author_mapper_test.dart
+++ b/frontend/test/screens/community/community_author_mapper_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:snowtrak/screens/community/mappers/community_author_mapper.dart';
+
+void main() {
+  // The same four cases the Python half is tested against. Two
+  // implementations of one rule is the cost of the community feed sending
+  // raw fields; testing them identically is what keeps them honest.
+  test('a chosen username wins and carries the at sign', () {
+    expect(
+      CommunityAuthorMapper.authorDisplayName(
+        username: 'snowking',
+        firstName: 'Matthew',
+        lastName: 'Ng',
+        fallback: 'matthew@example.com',
+      ),
+      '@snowking',
+    );
+  });
+
+  test('without a username the name shows with no at sign', () {
+    expect(
+      CommunityAuthorMapper.authorDisplayName(
+        username: null,
+        firstName: 'Matthew',
+        lastName: 'Ng',
+        fallback: 'matthew@example.com',
+      ),
+      'Matthew Ng',
+    );
+  });
+
+  test('with neither it falls back to the email handle', () {
+    expect(
+      CommunityAuthorMapper.authorDisplayName(
+        username: null,
+        firstName: null,
+        lastName: null,
+        fallback: 'skier@example.com',
+      ),
+      'skier',
+    );
+  });
+
+  test('a blank username counts as absent', () {
+    expect(
+      CommunityAuthorMapper.authorDisplayName(
+        username: '   ',
+        firstName: 'Matthew',
+        lastName: 'Ng',
+        fallback: 'matthew@example.com',
+      ),
+      'Matthew Ng',
+    );
+  });
+
+  test('a fallback with no @ to split on reads as gone entirely', () {
+    expect(
+      CommunityAuthorMapper.authorDisplayName(
+        username: null,
+        firstName: null,
+        lastName: null,
+        fallback: 'unknown',
+      ),
+      'Skier',
+    );
+  });
+
+  test('an empty fallback also reads as gone entirely', () {
+    expect(
+      CommunityAuthorMapper.authorDisplayName(
+        username: '',
+        firstName: '  ',
+        lastName: null,
+        fallback: '',
+      ),
+      'Skier',
+    );
+  });
+}


### PR DESCRIPTION
## Description

`public.profiles` was a dead table. Its `id` carried a foreign key to Supabase
auth's `users`, but registration writes `user_info`, so every insert failed
with `23503`. The table held **0 rows for 41 users**: profile edits 500ed and
every uploaded avatar URL was discarded. This repairs it, and makes a chosen
username the name every surface shows.

- **Migration 022** re-points `profiles.id` at `user_info(id) on delete
  cascade`, backfills one row per user, drops `profiles.full_name`, and adds
  `user_info.username` with a unique index on `lower(username)`.
- **`username` moves to `user_info`**, behind its own route
  (`PUT /api/v1/users/me/username`), and is carried through all 14 author
  embeds so the feed, comments, quotes and mentions can render it.
- **One display ladder**, stated once and implemented twice — Python
  (`backend/shared/display_name.py`) for surfaces that send a finished name,
  Dart (`community_author_mapper.dart`) for the feed, which sends raw fields:

  ```text
  @username      when the user has set one
  First Last     when they have not
  email handle   when they have neither
  Skier          when the author is gone entirely
  ```

- **Identity overlay.** `full_name`, `username` and `country_code` no longer
  live on `profiles`, so every `profiles`-backed response reads them from
  `user_info` unconditionally. Without this the backfill would have *blanked*
  the profile screen for all 41 users the moment 022 was applied — the row
  would start existing, and the columns would not.
- **Avatar upload fixed.** It now ensures a `profiles` row exists before
  writing (a brand-new user had none, so the write 500ed and orphaned the
  uploaded file), and returns the overlaid response instead of a bare row
  with a null name.
- **Invented handles deleted.** `usernameFromEmailOrId` and four hand-rolled
  fallback ladders are gone. Nothing stamps an `@` on an email local part any
  more — that leaked the real name of anyone who chose a handle to hide it.

Closes #43.

> [!IMPORTANT]
> **Migration 022 has already been applied to the live database.** It was
> hand-run in the Supabase SQL editor on 2026-09-05 and verified: 41
> `user_info` / 41 `profiles`, `user_info.username` present,
> `profiles.full_name` and `profiles.username` gone. Nothing further is
> needed at deploy time.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Docs or CI/infra update

## Testing

- [x] Local testing
- [x] Manual testing against the running stack
- [ ] Ran full CI locally

```
backend/main-backend       69 passed, 1 skipped
backend/community-backend  114 passed
backend/activity-backend   72 passed
backend/shared               6 passed
frontend                    75 passed   (dart analyze: no issues)
ruff check backend/        All checks passed
```

**Live verification** against the running stack after 022 was applied, using a
throwaway probe account (deleted afterwards; counts back to 41/41):

```
set:       {"username":"snowking"}     # "SnowKing" stored lowercased
profile:   snowking
full_name: "Probe User"                # the identity overlay
taken:     200                         # re-saving your own handle is not a 409
POST /posts                author_username = 'snowking'
GET  /posts/{id}           author_username = 'snowking'
GET  /posts/{id}/comments  author_username = 'snowking'
avatar upload -> avatar_url persists and reads back
```

A `profiles` row was created for a brand-new user — the table that had held
zero rows since inception now writes.

New tests were each confirmed **failing against the pre-fix code** before
being accepted: `tests/test_avatar.py` (`assert 500 == 200`, `assert None ==
'snowking'`) and `tests/test_profile.py` (6 of 7 failing pre-fix).

## Checklist

- [x] I have self-reviewed my code
- [x] I have added tests
- [x] I have updated docs (`docs/service-ownership.md`, regenerated
      `docs/database_schema.md`)
- [x] My commit messages follow Conventional Commits
- [x] No uncommitted secrets or large files in this PR
- [ ] CI passes — see checks below

## One unrelated commit, called out deliberately

`test(competition): anchor duel-accept fixture to the real clock` fixes a
pre-existing failure that has nothing to do with this branch.
`test_duel_routes.py` hardcoded `NOW = datetime(2026, 9, 2, 12, 0)` while
`INVITE_TTL` is 48 hours, so the test only ever passed within two days of the
date typed into it. It arrived with #46 and is already on `develop`, so
`develop` is red for the same reason. Fixed here because a red suite blocks
review. Test-file only; no production code.

## Follow-ups filed, not fixed here

| Issue | Why it was left |
|---|---|
| #53 | A chosen handle cannot reach an optimistic draft — needs `username` on the auth payload, a cross-service change. Two `TODO(#53)` comments name the ceiling. |
| #54 | Nothing structurally keeps the Python and Dart ladders in step; they agree today because two reviewers checked by eye. |
| #55 | Renaming yourself leaves a stale name in the composer, settings, greeting and header until `refreshUserData()` runs. |
| #56 | `list_comments_by_post` is an unbounded `SELECT` on a growing table. Adding pagination is a two-sided break. |
| #57 | `profiles.country_code` is a dead duplicate that migration 021 never dropped. Needs its own migration. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015npbKaSNS6MbCJi4Khs54M
