### PR TITLE
fix(activity): scope ActivityProvider to the signed-in user

### DIFF
--- a/backend/activity-backend/services/supabase_client.py
+++ b/backend/activity-backend/services/supabase_client.py
@@ -218,6 +218,24 @@ class ActivitySupabaseClient:
         start_date: str | None = None,
         end_date: str | None = None,
     ) -> dict[str, Any]:
+        """One user's own activities, newest first.
+
+        Unlike `list_activities` this needs no visibility filter: every row
+        it can reach is already the caller's own.
+
+        Args:
+            user_id: Whose activities to return.
+            limit: Max rows to return.
+            offset: Rows to skip, for pagination.
+            search: Case-insensitive substring match on the name.
+            activity_type: Exact match on the activity type.
+            start_date: Inclusive lower bound on `created_at`.
+            end_date: Inclusive upper bound on `created_at`.
+
+        Returns:
+            `{"items": [...], "total": n}` -- `total` counts all matching
+            rows, not just the returned page.
+        """
         query = (
             self._client.table("activities")
             .select("*", count=CountMethod.exact)
@@ -231,7 +249,11 @@ class ActivitySupabaseClient:
             query = query.gte("created_at", start_date)
         if end_date:
             query = query.lte("created_at", end_date)
-        query = query.range(offset, offset + limit - 1)
+        # Explicit ordering, not decoration: `range` paginates an unordered
+        # result set, so without this a row can appear on two pages or on
+        # none. Matches `list_activities`, which the caller may page against
+        # interchangeably.
+        query = query.order("created_at", desc=True).range(offset, offset + limit - 1)
         resp = query.execute()
         data = getattr(resp, "data", []) or []
         total = getattr(resp, "count", 0) or 0

--- a/backend/activity-backend/tests/test_activities_list_ordering.py
+++ b/backend/activity-backend/tests/test_activities_list_ordering.py
@@ -1,0 +1,145 @@
+"""`/activities/me` paging depends on an explicit ordering.
+
+PostgREST's `range` slices whatever order the planner happened to return, so
+a query with no ORDER BY can put one row on two pages and another on none.
+That is not hypothetical here: the frontend pages this endpoint into the
+list Home, Profile, Progress and the map all read.
+
+The fake below applies the filters, the ordering and the slice the way
+Postgres does, and holds its rows oldest-first. A missing `.order()`
+therefore shows up as rows in the wrong order or a row seen twice -- a
+behaviour, not an un-asserted call on a mock.
+"""
+
+from typing import Any
+
+from services.supabase_client import ActivitySupabaseClient
+
+ALEX = "alex"
+BLAKE = "blake"
+
+
+def _row(activity_id: str, created_at: str, user_id: str = ALEX) -> dict[str, Any]:
+    return {
+        "id": activity_id,
+        "user_id": user_id,
+        "name": activity_id,
+        "activity_type": "alpine",
+        "created_at": created_at,
+    }
+
+
+class _Response:
+    def __init__(self, data, count):
+        self.data = data
+        self.count = count
+
+
+class _Query:
+    """The slice of PostgREST that `list_user_activities` uses."""
+
+    def __init__(self, rows):
+        self._rows = list(rows)
+        self._order: tuple[str, bool] | None = None
+        self._range: tuple[int, int] | None = None
+
+    def select(self, *_args, **_kwargs):
+        return self
+
+    def eq(self, column, value):
+        self._rows = [row for row in self._rows if row.get(column) == value]
+        return self
+
+    def ilike(self, column, pattern):
+        needle = pattern.strip("%").lower()
+        self._rows = [row for row in self._rows if needle in str(row.get(column, "")).lower()]
+        return self
+
+    def gte(self, column, value):
+        self._rows = [row for row in self._rows if row.get(column) >= value]
+        return self
+
+    def lte(self, column, value):
+        self._rows = [row for row in self._rows if row.get(column) <= value]
+        return self
+
+    def order(self, column, desc=False):
+        self._order = (column, desc)
+        return self
+
+    def range(self, start, end):
+        self._range = (start, end)
+        return self
+
+    def execute(self):
+        rows = self._rows
+        # `count` is exact over the filtered set, before the slice, which is
+        # what CountMethod.exact gives.
+        total = len(rows)
+        if self._order is not None:
+            column, desc = self._order
+            rows = sorted(rows, key=lambda row: row[column], reverse=desc)
+        if self._range is not None:
+            start, end = self._range
+            rows = rows[start : end + 1]
+        return _Response(rows, total)
+
+
+class _FakeClient:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def table(self, _name):
+        return _Query(self._rows)
+
+
+#: Deliberately oldest-first. Without an ORDER BY the fake hands them back in
+#: this order, which is the wrong one for every caller.
+ROWS = [
+    _row("oldest", "2026-08-28T09:00:00Z"),
+    _row("older", "2026-08-29T09:00:00Z"),
+    _row("newer", "2026-08-30T09:00:00Z"),
+    _row("newest", "2026-08-31T09:00:00Z"),
+    _row("blake-newest", "2026-09-01T09:00:00Z", user_id=BLAKE),
+]
+
+
+def _client() -> ActivitySupabaseClient:
+    return ActivitySupabaseClient(_FakeClient(ROWS))
+
+
+def test_returns_newest_first():
+    result = _client().list_user_activities(user_id=ALEX, limit=10)
+
+    assert [row["id"] for row in result["items"]] == [
+        "newest",
+        "newer",
+        "older",
+        "oldest",
+    ]
+
+
+def test_pages_neither_repeat_nor_skip_a_row():
+    client = _client()
+    first = client.list_user_activities(user_id=ALEX, limit=2, offset=0)
+    second = client.list_user_activities(user_id=ALEX, limit=2, offset=2)
+
+    seen = [row["id"] for row in first["items"] + second["items"]]
+    assert seen == ["newest", "newer", "older", "oldest"]
+    assert len(set(seen)) == 4
+
+
+def test_only_the_owners_rows_and_an_owner_scoped_total():
+    result = _client().list_user_activities(user_id=ALEX, limit=10)
+
+    assert {row["user_id"] for row in result["items"]} == {ALEX}
+    # The total drives "has more"; counting somebody else's rows would page
+    # the client off the end of its own list.
+    assert result["total"] == 4
+
+
+def test_filters_still_narrow_the_ordered_set():
+    result = _client().list_user_activities(user_id=ALEX, search="old", limit=10)
+
+    assert [row["id"] for row in result["items"]] == ["older", "oldest"]
+    assert result["total"] == 2

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -76,8 +76,18 @@ class _SnowtrakAppState extends State<SnowtrakApp> {
             return previous;
           },
         ),
-        ChangeNotifierProvider<ActivityProvider>(
+        // Proxied on auth, not a plain provider: ActivityProvider holds the
+        // signed-in user's own activities, so it has to be told whose and
+        // to drop the last account's when that changes. AuthProvider
+        // notifies on sign-in, sign-out and a restored session, which is
+        // every moment the answer moves.
+        ChangeNotifierProxyProvider<AuthProvider, ActivityProvider>(
           create: (_) => sl<ActivityProvider>(),
+          update: (_, auth, previous) {
+            final activities = previous ?? sl<ActivityProvider>();
+            unawaited(activities.setOwner(auth.user?.id));
+            return activities;
+          },
         ),
         Provider<ActivitiesContextRepository>(
           create: (_) => sl<ActivitiesContextRepository>(),

--- a/frontend/lib/providers/activity_provider.dart
+++ b/frontend/lib/providers/activity_provider.dart
@@ -10,6 +10,16 @@ import 'package:snowtrak/services/activities_service.dart';
 import 'package:snowtrak/services/feed/activities_feed_cache.dart';
 import 'package:snowtrak/services/feed/feed_rebase.dart';
 
+/// The signed-in user's own activities, and the stats derived from them.
+///
+/// Owner-scoped, and every reader depends on that: Home's carousel totals
+/// these, the profile's training block lists them, Progress builds streaks
+/// and a calendar from them, and the map draws their tracks. It used to
+/// hold `GET /activities/` -- the public discovery feed -- so all four
+/// showed strangers' skiing as the viewer's own (#58).
+///
+/// [setOwner] is not optional wiring. Nothing else drops the previous
+/// account's rows when somebody signs out on a shared device.
 class ActivityProvider extends ChangeNotifier {
   ActivityProvider(
     this._activitiesService,
@@ -33,6 +43,31 @@ class ActivityProvider extends ChangeNotifier {
   bool get hasMore => _hasMore;
   String? get error => _error;
   UserStats? get stats => _stats;
+
+  /// Points the provider at one account and forgets the last one.
+  ///
+  /// Wired to AuthProvider in `main.dart`, so sign-in, sign-out and a
+  /// restored session all reach it. Both stores have to be dropped: the
+  /// in-memory list is what the first frame after a switch paints, and the
+  /// cached pages are what the frame after that paints.
+  Future<void> setOwner(String? userId) async {
+    if (userId == _feedCache.owner) return;
+
+    // Cleared before the owner changes, so this removes the *outgoing*
+    // account's pages. It also yields, which keeps the notifyListeners
+    // below out of the build that triggered the change.
+    await _feedCache.clear();
+    _feedCache.owner = userId;
+
+    _activities = [];
+    _stats = null;
+    _currentPage = 1;
+    _hasMore = true;
+    _isLoading = false;
+    _isLoadingMore = false;
+    _error = null;
+    notifyListeners();
+  }
 
   Future<void> hydrateFromCache() async {
     final cached = await _feedCache.readPage(1);
@@ -72,7 +107,7 @@ class ActivityProvider extends ChangeNotifier {
     }
 
     final previousLocal = List<Activity>.from(_activities);
-    final result = await _activitiesService.getActivities(
+    final result = await _activitiesService.getMyActivities(
       page: 1,
       limit: _pageSize,
     );
@@ -136,7 +171,7 @@ class ActivityProvider extends ChangeNotifier {
     _isLoadingMore = true;
     notifyListeners();
 
-    final result = await _activitiesService.getActivities(
+    final result = await _activitiesService.getMyActivities(
       page: targetPage,
       limit: _pageSize,
     );
@@ -171,7 +206,7 @@ class ActivityProvider extends ChangeNotifier {
     final cached = await _feedCache.readPage(page);
     if (cached != null && cached.isNotEmpty) return;
 
-    final result = await _activitiesService.getActivities(
+    final result = await _activitiesService.getMyActivities(
       page: page,
       limit: _pageSize,
     );

--- a/frontend/lib/screens/home/home_feed_screen.dart
+++ b/frontend/lib/screens/home/home_feed_screen.dart
@@ -153,8 +153,11 @@ class _HomeFeedScreenState extends State<HomeFeedScreen> {
                         const SizedBox(height: SnowtrakSpacing.md),
                         RecentActivitySection(
                           activities: activities,
+                          // Profile, not Community: the section lists the
+                          // viewer's own activities, and Profile's
+                          // Activities tab is where all of them live.
                           onSeeAll: () =>
-                              HomeTabScope.selectTabOrNull(context, HomeTab.community),
+                              HomeTabScope.selectTabOrNull(context, HomeTab.profile),
                           onOpenActivity: _openActivity,
                         ),
                       ],

--- a/frontend/lib/screens/home/widgets/recent_activity_section.dart
+++ b/frontend/lib/screens/home/widgets/recent_activity_section.dart
@@ -6,9 +6,11 @@ import 'package:snowtrak/ui/st/st.dart';
 
 /// Compact activity rows under the statistics carousel — 74pt cards, per
 /// `07 · Screens — Home`.
-// ponytail: the design calls this "Friends' Recent Activity"; there is no
-// following-feed endpoint yet, so it shows the activities feed we do have.
-// Rename + swap the source when the social feed lands.
+// ponytail: the design calls this "Friends' Recent Activity". There is no
+// following-feed endpoint, so it shows the viewer's own activities and says
+// so. It used to show the public feed instead, which put strangers under a
+// heading that reads as personal (#58). Rename and swap the source back
+// when the following feed lands (#59).
 class RecentActivitySection extends StatelessWidget {
   const RecentActivitySection({
     super.key,
@@ -27,7 +29,7 @@ class RecentActivitySection extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         StSectionHeader(
-          title: 'Recent activity',
+          title: 'Your recent activity',
           actionLabel: 'See all',
           onAction: onSeeAll,
         ),

--- a/frontend/lib/services/activities_service.dart
+++ b/frontend/lib/services/activities_service.dart
@@ -42,6 +42,25 @@ class ActivitiesService {
     }
   }
 
+  /// The signed-in user's own activities, newest first.
+  ///
+  /// Paged the same way as [getActivities] so a caller can hold one or the
+  /// other without knowing which; the endpoint underneath takes an offset.
+  Future<AppResult<List<Activity>>> getMyActivities({
+    int page = 1,
+    int limit = 20,
+  }) async {
+    try {
+      final list = await _activitiesRepository.getMyActivities(
+        limit: limit,
+        offset: (page - 1) * limit,
+      );
+      return AppSuccess(list);
+    } catch (e, st) {
+      return AppFailure(AppError.from(e, st));
+    }
+  }
+
   Future<AppResult<Activity>> getActivity(String id) async {
     try {
       final activity = await _activitiesRepository.getActivity(id);

--- a/frontend/lib/services/feed/activities_feed_cache.dart
+++ b/frontend/lib/services/feed/activities_feed_cache.dart
@@ -1,15 +1,35 @@
 import 'package:snowtrak/models/activity.dart';
 import 'package:snowtrak/services/feed/feed_cache_store.dart';
 
+/// On-device pages of the viewer's own activities.
+///
+/// Scoped per account. The pages are one person's activity history, some of
+/// it `private`, and this device is shared: without a scope the next person
+/// to sign in reads the last one's rows straight off disk, before any
+/// request goes out. [owner] is what keeps those apart, and [clear] is what
+/// removes them on the way out.
 class ActivitiesFeedCache {
+  /// `_v2` because `_v1` holds pages of the *public* feed, written when
+  /// ActivityProvider read `/activities/`. An install upgrading in place
+  /// would otherwise paint strangers' runs from disk on the first frame and
+  /// look unfixed. The old keys age out on their own TTL.
   ActivitiesFeedCache({FeedCacheStore? store})
       : _store = store ??
-            FeedCacheStore(storageKeyPrefix: 'activities_feed_cache_v1');
+            FeedCacheStore(storageKeyPrefix: 'activities_feed_cache_v2');
 
   static const cacheTtl = Duration(minutes: 30);
-  static const _scope = 'default';
+
+  /// Before anyone signs in. Nothing is written here in practice --
+  /// ActivityProvider has no activities to cache until it has an owner --
+  /// but a read needs a key either way.
+  static const anonymousScope = 'anonymous';
 
   final FeedCacheStore _store;
+
+  /// The account these pages belong to, or null before sign-in.
+  String? owner;
+
+  String get _scope => owner ?? anonymousScope;
 
   Future<List<Activity>?> readPage(int page) async {
     final rawItems = await _store.readPage(
@@ -30,5 +50,7 @@ class ActivitiesFeedCache {
     );
   }
 
+  /// Removes the current owner's pages. Not the whole prefix: another
+  /// account's pages are not this one's to delete.
   Future<void> clear() => _store.clearScope(_scope);
 }

--- a/frontend/test/README.md
+++ b/frontend/test/README.md
@@ -15,7 +15,8 @@ test/
 │   └── test_storage_service.dart
 ├── providers/
 │   ├── test_auth_provider.dart
-│   └── test_activity_provider.dart
+│   ├── activity_provider_test.dart
+│   └── notification_provider_test.dart
 ├── widgets/
 │   └── test_login_screen.dart
 └── widget_test.dart         # Basic app test

--- a/frontend/test/providers/activity_provider_test.dart
+++ b/frontend/test/providers/activity_provider_test.dart
@@ -1,0 +1,237 @@
+/// ActivityProvider is owner-scoped, and four screens depend on that.
+///
+/// Home's stats carousel, the profile training block, Progress' streaks and
+/// the map all render whatever this provider holds. It used to hold
+/// `GET /activities/` -- the public discovery feed -- so all four showed
+/// other people's skiing as the viewer's own (#58). The endpoint tests below
+/// are what stop that coming back; the owner tests are what stop the same
+/// rows outliving a sign-out on a shared device.
+library;
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:snowtrak/core/config/app_config.dart';
+import 'package:snowtrak/core/config/app_environment.dart';
+import 'package:snowtrak/core/errors/app_error.dart';
+import 'package:snowtrak/core/errors/app_result.dart';
+import 'package:snowtrak/features/activities/data/activities_repository.dart';
+import 'package:snowtrak/models/activity.dart';
+import 'package:snowtrak/models/user_stats.dart';
+import 'package:snowtrak/providers/activity_provider.dart';
+import 'package:snowtrak/services/activities_service.dart';
+import 'package:snowtrak/services/apis/activities_api.dart';
+import 'package:snowtrak/services/feed/activities_feed_cache.dart';
+
+Activity _activity(String id, {String userId = 'alex'}) {
+  final at = DateTime.utc(2026, 9, 1, 9);
+  return Activity(
+    id: id,
+    userId: userId,
+    type: ActivityType.alpine,
+    name: id,
+    distance: 1000,
+    duration: 600,
+    elevationGain: 500,
+    startTime: at,
+    endTime: at.add(const Duration(hours: 2)),
+    averagePace: 300,
+    maxPace: 0,
+    isPublic: true,
+    createdAt: at,
+  );
+}
+
+/// Records which endpoint the provider reached for.
+///
+/// Subclasses the real service rather than an interface, matching
+/// notification_provider_test.dart. `getActivities` is left live and
+/// answering, so a regression shows up as "read the feed" rather than as a
+/// crash that could be read as any other failure.
+class _RecordingActivitiesService extends ActivitiesService {
+  _RecordingActivitiesService({
+    AppEnvironment environment = AppEnvironment.prod,
+  }) : super(
+          activitiesRepository: ActivitiesRepository(ActivitiesApi(dio: Dio())),
+          appConfig: AppConfig(
+            environment: environment,
+            mainApiBaseUrl: 'http://localhost',
+            activityApiBaseUrl: 'http://localhost',
+            communityApiBaseUrl: 'http://localhost',
+            mapApiBaseUrl: 'http://localhost',
+          ),
+        );
+
+  final List<String> calls = <String>[];
+  final List<int> requestedPages = <int>[];
+
+  /// Keyed by page, so a paging test can hand out different rows per page.
+  Map<int, List<Activity>> minePages = <int, List<Activity>>{};
+  List<Activity> feed = <Activity>[_activity('public-feed-row', userId: 'ana')];
+  bool fail = false;
+
+  @override
+  Future<AppResult<List<Activity>>> getActivities({
+    int page = 1,
+    int limit = 20,
+  }) async {
+    calls.add('getActivities');
+    return AppSuccess(feed);
+  }
+
+  @override
+  Future<AppResult<List<Activity>>> getMyActivities({
+    int page = 1,
+    int limit = 20,
+  }) async {
+    calls.add('getMyActivities');
+    requestedPages.add(page);
+    if (fail) {
+      return const AppFailure(AppError(userMessage: 'boom'));
+    }
+    return AppSuccess(minePages[page] ?? const <Activity>[]);
+  }
+
+  @override
+  Future<AppResult<UserStats>> getMyStats() async {
+    return const AppFailure(AppError(userMessage: 'no stats'));
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _RecordingActivitiesService service;
+  late ActivitiesFeedCache cache;
+  late ActivityProvider provider;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    service = _RecordingActivitiesService();
+    cache = ActivitiesFeedCache();
+    provider = ActivityProvider(service, cache);
+  });
+
+  group('reads the owner-scoped endpoint', () {
+    test('loadActivities never touches the public feed', () async {
+      service.minePages = {
+        1: [_activity('mine-1'), _activity('mine-2')],
+      };
+
+      await provider.setOwner('alex');
+      await provider.loadActivities(refresh: true, forceNetwork: true);
+
+      expect(service.calls, ['getMyActivities']);
+      expect(
+        provider.activities.map((activity) => activity.id),
+        ['mine-1', 'mine-2'],
+      );
+      expect(
+        provider.activities.every((activity) => activity.userId == 'alex'),
+        isTrue,
+        reason: 'the provider must hold nobody else\'s activities',
+      );
+    });
+
+    test('loadMore pages the owner-scoped endpoint too', () async {
+      // A full first page is what sets hasMore, so loadMore has somewhere to
+      // go. _pageSize is 20.
+      service.minePages = {
+        1: List.generate(20, (index) => _activity('page1-$index')),
+        2: [_activity('page2-0')],
+      };
+
+      await provider.setOwner('alex');
+      await provider.loadActivities(refresh: true, forceNetwork: true);
+      expect(provider.hasMore, isTrue);
+
+      await provider.loadMore();
+
+      expect(service.calls, everyElement('getMyActivities'));
+      expect(service.requestedPages, containsAllInOrder([1, 2]));
+      expect(provider.activities.last.id, 'page2-0');
+    });
+
+    test('a failed load leaves the list empty, not filled from the feed',
+        () async {
+      service.fail = true;
+
+      await provider.setOwner('alex');
+      await provider.loadActivities(refresh: true, forceNetwork: true);
+
+      expect(service.calls, isNot(contains('getActivities')));
+      expect(provider.activities, isEmpty);
+      expect(provider.error, isNotNull);
+    });
+  });
+
+  group('owner switching', () {
+    test('drops the previous account\'s rows from memory', () async {
+      service.minePages = {
+        1: [_activity('alex-1')],
+      };
+      await provider.setOwner('alex');
+      await provider.loadActivities(refresh: true, forceNetwork: true);
+      expect(provider.activities, isNotEmpty);
+
+      await provider.setOwner('blake');
+
+      expect(provider.activities, isEmpty);
+      expect(provider.hasMore, isTrue);
+    });
+
+    test('signing out drops the previous account\'s cached pages', () async {
+      service.minePages = {
+        1: [_activity('alex-1')],
+      };
+      await provider.setOwner('alex');
+      await provider.loadActivities(refresh: true, forceNetwork: true);
+      // The write is what makes the next assertion meaningful.
+      expect(await cache.readPage(1), isNotNull);
+
+      await provider.setOwner(null);
+
+      cache.owner = 'alex';
+      expect(
+        await cache.readPage(1),
+        isNull,
+        reason: 'a signed-out account\'s activities must not survive on disk',
+      );
+    });
+
+    test('the same id twice is a no-op', () async {
+      service.minePages = {
+        1: [_activity('alex-1')],
+      };
+      await provider.setOwner('alex');
+      await provider.loadActivities(refresh: true, forceNetwork: true);
+
+      var notifications = 0;
+      provider.addListener(() => notifications++);
+      await provider.setOwner('alex');
+
+      // AuthProvider notifies on every profile refresh, and the proxy
+      // provider calls setOwner each time. Wiping the list on those would
+      // blank the screen at random.
+      expect(provider.activities, isNotEmpty);
+      expect(notifications, 0);
+    });
+
+    test('hydrateFromCache reads only the current owner\'s pages', () async {
+      service.minePages = {
+        1: [_activity('alex-1')],
+      };
+      await provider.setOwner('alex');
+      await provider.loadActivities(refresh: true, forceNetwork: true);
+
+      final other = ActivityProvider(
+        _RecordingActivitiesService(),
+        ActivitiesFeedCache(),
+      );
+      await other.setOwner('blake');
+      await other.hydrateFromCache();
+
+      expect(other.activities, isEmpty);
+    });
+  });
+}

--- a/frontend/test/providers/test_activity_provider.dart
+++ b/frontend/test/providers/test_activity_provider.dart
@@ -1,9 +1,0 @@
-import 'package:flutter_test/flutter_test.dart';
-
-void main() {
-  group('ActivityProvider (placeholder)', () {
-    test('provider tests require updated domain-service fakes', () {
-      expect(true, isTrue);
-    });
-  });
-}

--- a/frontend/test/services/feed/activities_feed_cache_test.dart
+++ b/frontend/test/services/feed/activities_feed_cache_test.dart
@@ -1,0 +1,103 @@
+/// The activities cache holds one person's activity history, some of it
+/// private, on a device more than one person may sign into. These tests are
+/// about the scope that keeps those apart -- not about caching working.
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:snowtrak/models/activity.dart';
+import 'package:snowtrak/services/feed/activities_feed_cache.dart';
+import 'package:snowtrak/services/feed/feed_cache_store.dart';
+
+Activity _activity(String id, {required String userId}) {
+  final at = DateTime.utc(2026, 9, 1, 9);
+  return Activity(
+    id: id,
+    userId: userId,
+    type: ActivityType.alpine,
+    name: id,
+    distance: 1000,
+    duration: 600,
+    elevationGain: 500,
+    startTime: at,
+    endTime: at.add(const Duration(hours: 2)),
+    averagePace: 300,
+    maxPace: 0,
+    isPublic: false,
+    createdAt: at,
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() => SharedPreferences.setMockInitialValues(<String, Object>{}));
+
+  test('one account cannot read another\'s pages', () async {
+    final cache = ActivitiesFeedCache();
+
+    cache.owner = 'alex';
+    await cache.writePage(1, [_activity('alex-1', userId: 'alex')]);
+
+    cache.owner = 'blake';
+    expect(await cache.readPage(1), isNull);
+
+    // And Alex's pages are still Alex's -- the scope separates, it does not
+    // overwrite.
+    cache.owner = 'alex';
+    expect(await cache.readPage(1), hasLength(1));
+  });
+
+  test('clear removes the current owner\'s pages and leaves the rest',
+      () async {
+    final cache = ActivitiesFeedCache();
+
+    cache.owner = 'alex';
+    await cache.writePage(1, [_activity('alex-1', userId: 'alex')]);
+    cache.owner = 'blake';
+    await cache.writePage(1, [_activity('blake-1', userId: 'blake')]);
+
+    await cache.clear();
+
+    expect(await cache.readPage(1), isNull);
+    cache.owner = 'alex';
+    expect(
+      await cache.readPage(1),
+      hasLength(1),
+      reason: 'another account\'s pages are not this one\'s to delete',
+    );
+  });
+
+  test('pages written by the v1 public-feed cache are not read back',
+      () async {
+    // What an install upgrading in place actually has on disk: pages of
+    // GET /activities/, written under the old prefix and the old fixed
+    // scope. Reading them would paint strangers' runs on the first frame
+    // and make the fix look like it did not land.
+    final legacy = FeedCacheStore(storageKeyPrefix: 'activities_feed_cache_v1');
+    await legacy.writePage(
+      scope: 'default',
+      page: 1,
+      items: [_activity('ana-day-3', userId: 'ana').toCacheJson()],
+    );
+
+    final cache = ActivitiesFeedCache()..owner = 'alex';
+    expect(await cache.readPage(1), isNull);
+
+    // Also nothing for a signed-out reader, which is what 'default' would
+    // most plausibly collide with.
+    cache.owner = null;
+    expect(await cache.readPage(1), isNull);
+  });
+
+  test('a page survives a round trip for the owner that wrote it', () async {
+    final cache = ActivitiesFeedCache()..owner = 'alex';
+
+    await cache.writePage(1, [_activity('alex-1', userId: 'alex')]);
+
+    final read = await cache.readPage(1);
+    expect(read, isNotNull);
+    expect(read!.single.id, 'alex-1');
+    expect(read.single.userId, 'alex');
+  });
+}


### PR DESCRIPTION
## Description

`ActivityProvider` was filled from `GET /activities/` — the public discovery
feed — while four surfaces read it as the viewer's own record. Home's stats
carousel totalled strangers' kilometres (336.8 mi / 120h for an account that
had skied none of it), Home's "Recent activity" listed their runs, the
profile training block and Progress' streaks and calendar were built from
them, and the map drew their tracks.

`profile_home_content.dart:19` already documented the opposite invariant —
"ActivityProvider only ever holds the signed-in user's activities and
stats" — and gates other people's profiles on it. The provider did not
honour it.

Invisible until the dev database held more than one account: with
`activities` effectively empty, the feed and "my activities" returned the
same rows. Seeding 45 public activities across 12 accounts separated them.

**Not a privacy leak.** `list_activities` filters through
`visible_rows_expression(viewer_id, following)` server-side, so only
own + followed + public rows were ever returned. The bug was rendering a
discovery feed as a personal record.

Closes #58.

## What changed

Three things had to move together, which is why this is not a three-line
diff:

- **The provider reads the owner-scoped endpoint.** All three load paths
  call a new `ActivitiesService.getMyActivities`, paged the same way as
  `getActivities` so the provider does not care which it holds.

- **The disk cache had to stop outliving an account.** It was one fixed
  scope, `clear()` was never called from anywhere, and pointing the provider
  at personal data would have turned a cosmetic bug into a real one: account
  B reading account A's private activities off disk on the first frame.
  Pages are now scoped by user id, `setOwner` drops the outgoing account's,
  and the prefix is bumped to `_v2` so an install upgrading in place does
  not paint v1's public-feed pages and look unfixed. `setOwner` is wired
  through a `ChangeNotifierProxyProvider` on `AuthProvider` — the one place
  that sees sign-in, sign-out and a restored session — and no-ops on an
  unchanged id, because `AuthProvider` also notifies on every profile
  refresh.

- **`list_user_activities` had no ORDER BY.** PostgREST's `range` slices
  whatever order came back, so paging it could repeat one row and drop
  another. Now `created_at desc`, matching `list_activities`, per the
  "explicit ordering" rule in CLAUDE.md.

Home's section keeps its slot and says what it now shows — "Your recent
activity", with See all going to Profile rather than Community. The design
calls for a friends' feed there and there is no following-scoped endpoint to
build one from; #59 tracks that.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs or CI/infra update

## Testing

- [x] Local testing — `flutter test` 86 passed, `pytest` (activity-backend)
      76 passed, `ruff check .` clean, `dart analyze` clean
- [x] Manual testing on device/simulator — built and installed on the
      iPhone 16 simulator against the four local backends
- [ ] Ran full CI locally or via PR

**Every new test was checked to fail against the pre-fix code**, not just to
pass against the new one:

| Test file | Fails when |
|---|---|
| `test/providers/activity_provider_test.dart` (7) | the feed endpoint comes back (3 of 7 red); `setOwner` stops clearing the cache; the unchanged-id guard is removed |
| `test/services/feed/activities_feed_cache_test.dart` (4) | the old fixed scope or the old `_v1` prefix returns (3 red) |
| `activity-backend/tests/test_activities_list_ordering.py` (4) | `.order()` is removed (3 red) |

The backend fake applies order and range the way Postgres does over rows
held oldest-first, so a missing `.order()` surfaces as rows in the wrong
order or one row on two pages — a behaviour, not an un-asserted call on a
mock.

Live check against the running stack:

```
GET /activities/me?limit=2&offset=0  → Yuki day 4, Yuki day 3
GET /activities/me?limit=2&offset=2  → Yuki day 2, Yuki day 1
```

Newest-first, disjoint pages, one user id.

## Checklist

- [x] I have self-reviewed my code
- [x] I have added tests
- [x] I have updated docs (test/README.md structure block)
- [x] My commit messages follow the Conventional Commits format
- [x] No uncommitted secrets or large files in this PR
- [ ] CI passes — pending on this PR

## Notes for the reviewer

Three things reported rather than fixed:

- `flutter analyze` crashes in my environment (analysis server exit 64,
  pre-existing and unrelated to this diff). `dart analyze` was run instead
  and is clean.
- `ruff format --check` reports 22 pre-existing unformatted files repo-wide.
  The two touched here are formatted; I did not sweep the rest.
- `mypy activity-backend/services/supabase_client.py` reports the same 11
  pre-existing errors before and after this change.

Also replaces `test/providers/test_activity_provider.dart`, an 8-line
placeholder that asserted `true == true` and said the fakes it needed did
not exist. Its filename did not match `*_test.dart`, so `flutter test` had
never run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DULjcJmHVP9t8TbBoMrqeY
