### PR TITLE
fix(profile): show lifetime totals from cached stats instead of one page

### DIFF
--- a/backend/activity-backend/routes/stats_routes.py
+++ b/backend/activity-backend/routes/stats_routes.py
@@ -15,13 +15,21 @@ router = APIRouter()
 
 @router.get("/me/stats", response_model=UserStatsResponse)
 async def get_my_stats(user_id: str = Depends(get_current_user)):
-    """Return cached stats for the authenticated user.
+    """Return the authenticated user's stats, recomputing on a cache miss.
 
-    No cached row means the user has no activities yet — returns zeros without
-    touching the DB. The cache is first written when they create an activity.
+    A missing row in `user_stats` means nobody has written one yet — it does
+    not mean the user has no activities. `recompute_and_upsert` only fires on
+    activity create/update/delete and pipeline completion, so an account
+    seeded straight into `activities` (bypassing those paths) has real
+    activities and no cached row. A cache miss recomputes from the activities
+    table and persists the result, self-healing that account on this request.
+    Zeros are returned only when the recompute itself finds nothing.
     """
     stats_service = get_stats_service()
     stats = stats_service.get_stats(user_id)
+
+    if stats is None:
+        stats = stats_service.recompute_and_upsert(user_id)
 
     if stats is None:
         today = date.today()

--- a/backend/activity-backend/routes/stats_routes.py
+++ b/backend/activity-backend/routes/stats_routes.py
@@ -23,7 +23,9 @@ async def get_my_stats(user_id: str = Depends(get_current_user)):
     seeded straight into `activities` (bypassing those paths) has real
     activities and no cached row. A cache miss recomputes from the activities
     table and persists the result, self-healing that account on this request.
-    Zeros are returned only when the recompute itself finds nothing.
+    A user with genuinely no activities gets a persisted zeros row from
+    the recompute, so the in-route zero fallback below only fires when
+    the recompute itself fails (e.g. the DB is unreachable).
     """
     stats_service = get_stats_service()
     stats = stats_service.get_stats(user_id)

--- a/backend/activity-backend/services/user_stats_service.py
+++ b/backend/activity-backend/services/user_stats_service.py
@@ -57,14 +57,21 @@ class UserStatsService:
     def recompute_and_upsert(self, user_id: str) -> dict[str, Any] | None:
         """Recompute stats from all activities and persist.
 
-        If no activities remain (e.g. user deleted their last one), removes the
-        stale row so the route returns zeros without a spurious DB read.
+        A user with no activities still gets a persisted zeros row, not a
+        deleted one -- without a row to hit, a cache miss for a zero-activity
+        account (overwhelmingly new signups, since this now runs on every
+        `GET /me/stats` cache miss) would re-run this full recompute on
+        every single request forever. A zeros row is also the correct answer
+        for someone who deletes their last activity.
         """
         try:
             activities = self._fetch_all_activities(user_id)
-            if not activities:
-                self._delete_row(user_id)
-                return None
+            if len(activities) == self._MAX_ACTIVITIES_FOR_RECOMPUTE:
+                logger.warning(
+                    "User %s has >= %d activities; all-time stats are truncated",
+                    user_id,
+                    self._MAX_ACTIVITIES_FOR_RECOMPUTE,
+                )
             stats = _compute_stats(user_id, activities)
             return self._upsert(stats)
         except Exception:
@@ -91,9 +98,6 @@ class UserStatsService:
         )
         data = getattr(resp, "data", None)
         return data[0] if data else None
-
-    def _delete_row(self, user_id: str) -> None:
-        self._client.table("user_stats").delete().eq("user_id", user_id).execute()
 
 
 def _compute_stats(user_id: str, activities: list[dict[str, Any]]) -> dict[str, Any]:

--- a/backend/activity-backend/services/user_stats_service.py
+++ b/backend/activity-backend/services/user_stats_service.py
@@ -32,6 +32,14 @@ def get_stats_service() -> UserStatsService:
 class UserStatsService:
 
     _STATS_COLUMNS = "start_time,duration_seconds,distance_meters,elevation_gain_meters"
+    # ponytail: a full recompute genuinely needs every activity, but
+    # GET /me/stats now runs this on a cache miss (a request path), so an
+    # unconditional SELECT * is no longer acceptable per CLAUDE.md Rule 3.
+    # 5,000 rows ordered newest-first caps memory and query time; an account
+    # past that ceiling gets an all-time total missing its oldest activities
+    # rather than an unbounded query landing on every profile-open. Revisit
+    # with real pagination if this cap is ever hit in practice.
+    _MAX_ACTIVITIES_FOR_RECOMPUTE = 5000
 
     def __init__(self, client) -> None:
         self._client = client
@@ -69,6 +77,8 @@ class UserStatsService:
             .select(self._STATS_COLUMNS)
             .eq("user_id", user_id)
             .not_.in_("processing_status", ["pending", "uploading", "processing"])
+            .order("start_time", desc=True)
+            .limit(self._MAX_ACTIVITIES_FOR_RECOMPUTE)
             .execute()
         )
         return getattr(resp, "data", None) or []

--- a/backend/activity-backend/tests/test_stats_routes.py
+++ b/backend/activity-backend/tests/test_stats_routes.py
@@ -1,0 +1,96 @@
+"""GET /me/stats must not answer a cache miss with zeros when activities exist.
+
+`user_stats` is a cache: rows are only written when `recompute_and_upsert`
+runs, and 25 seed activities were inserted straight into `activities`,
+bypassing every path that triggers it. A missing row means nobody has
+written one -- not that the user has no activities -- so the route needs to
+recompute on a miss rather than assert zeros.
+"""
+
+from fastapi import status
+
+import routes.stats_routes as stats_routes
+
+
+class FakeStatsService:
+    """Stands in for `UserStatsService`: no DB, calls recorded."""
+
+    def __init__(self, cached=None, recomputed=None):
+        self._cached = cached
+        self._recomputed = recomputed
+        self.recompute_calls: list[str] = []
+
+    def get_stats(self, user_id):
+        return self._cached
+
+    def recompute_and_upsert(self, user_id):
+        self.recompute_calls.append(user_id)
+        return self._recomputed
+
+
+def _stats_row(user_id="user-1", **overrides):
+    row = {
+        "user_id": user_id,
+        "week_start": "2026-08-31",
+        "weekly_distance_km": 12.5,
+        "weekly_time_min": 90,
+        "weekly_elev_gain_m": 400.0,
+        "weekly_session_count": 2,
+        "last_week_session_count": 1,
+        "yearly_distance_km": 300.0,
+        "yearly_time_min": 1800,
+        "yearly_elev_gain_m": 9000.0,
+        "yearly_session_count": 40,
+        "all_time_distance_km": 987.6,
+        "all_time_time_min": 5400,
+        "all_time_elev_gain_m": 45000.0,
+        "all_time_session_count": 123,
+        "current_streak_weeks": 3,
+        "longest_streak_weeks": 5,
+        "activity_days": ["2026-08-30"],
+        "best_efforts": [],
+    }
+    row.update(overrides)
+    return row
+
+
+def test_cache_miss_with_real_activities_recomputes_instead_of_zeros(client, app, monkeypatch):
+    """A missing row for an account that has activities must not read as zero."""
+    recomputed = _stats_row(all_time_session_count=123, all_time_distance_km=987.6)
+    fake_service = FakeStatsService(cached=None, recomputed=recomputed)
+    monkeypatch.setattr(stats_routes, "get_stats_service", lambda: fake_service)
+
+    response = client.get("/api/v1/activities/me/stats")
+
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    assert body["all_time_session_count"] == 123
+    assert body["all_time_distance_km"] == 987.6
+    assert fake_service.recompute_calls == ["user-1"]
+
+
+def test_cache_miss_with_no_activities_still_returns_zeros(client, app, monkeypatch):
+    """A genuinely activity-less account still reads as zero, not an error."""
+    fake_service = FakeStatsService(cached=None, recomputed=None)
+    monkeypatch.setattr(stats_routes, "get_stats_service", lambda: fake_service)
+
+    response = client.get("/api/v1/activities/me/stats")
+
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    assert body["all_time_session_count"] == 0
+    assert body["all_time_distance_km"] == 0
+    assert fake_service.recompute_calls == ["user-1"]
+
+
+def test_cache_hit_never_recomputes(client, app, monkeypatch):
+    """A cached row is trusted as-is -- no request-path recompute on a hit."""
+    cached = _stats_row(all_time_session_count=7)
+    fake_service = FakeStatsService(cached=cached, recomputed=None)
+    monkeypatch.setattr(stats_routes, "get_stats_service", lambda: fake_service)
+
+    response = client.get("/api/v1/activities/me/stats")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["all_time_session_count"] == 7
+    assert fake_service.recompute_calls == []

--- a/backend/activity-backend/tests/test_stats_routes.py
+++ b/backend/activity-backend/tests/test_stats_routes.py
@@ -13,11 +13,18 @@ import routes.stats_routes as stats_routes
 
 
 class FakeStatsService:
-    """Stands in for `UserStatsService`: no DB, calls recorded."""
+    """Stands in for `UserStatsService`: no DB, calls recorded.
 
-    def __init__(self, cached=None, recomputed=None):
+    `persist_recompute=True` mimics the real service's fix for a
+    zero-activity user: a recompute now persists a row (see
+    `UserStatsService.recompute_and_upsert`), so the *next* `get_stats` call
+    is a hit rather than another miss.
+    """
+
+    def __init__(self, cached=None, recomputed=None, persist_recompute=False):
         self._cached = cached
         self._recomputed = recomputed
+        self._persist_recompute = persist_recompute
         self.recompute_calls: list[str] = []
 
     def get_stats(self, user_id):
@@ -25,6 +32,8 @@ class FakeStatsService:
 
     def recompute_and_upsert(self, user_id):
         self.recompute_calls.append(user_id)
+        if self._persist_recompute:
+            self._cached = self._recomputed
         return self._recomputed
 
 
@@ -69,8 +78,14 @@ def test_cache_miss_with_real_activities_recomputes_instead_of_zeros(client, app
     assert fake_service.recompute_calls == ["user-1"]
 
 
-def test_cache_miss_with_no_activities_still_returns_zeros(client, app, monkeypatch):
-    """A genuinely activity-less account still reads as zero, not an error."""
+def test_cache_miss_with_a_failed_recompute_still_returns_zeros(client, app, monkeypatch):
+    """If the recompute itself can't run (e.g. DB unreachable), fall back to zero.
+
+    A genuinely zero-activity user does *not* hit this path any more -- the
+    real service persists a zeros row instead of returning None (see
+    `test_user_stats_service.py`), so `None` here now stands for "the
+    recompute failed", not "the user has no activities".
+    """
     fake_service = FakeStatsService(cached=None, recomputed=None)
     monkeypatch.setattr(stats_routes, "get_stats_service", lambda: fake_service)
 
@@ -80,6 +95,32 @@ def test_cache_miss_with_no_activities_still_returns_zeros(client, app, monkeypa
     body = response.json()
     assert body["all_time_session_count"] == 0
     assert body["all_time_distance_km"] == 0
+    assert fake_service.recompute_calls == ["user-1"]
+
+
+def test_second_request_for_a_zero_activity_user_is_not_a_second_recompute(
+    client, app, monkeypatch
+):
+    """A zero-activity user must not re-run the full recompute on every request.
+
+    Before the fix, a recompute that found no activities deleted the row
+    instead of persisting one, so there was never a row for the next
+    request to hit -- every single `/me/stats` call for that account
+    re-ran `_fetch_all_activities` (and re-issued a `DELETE`) forever. This
+    pins the route-level contract: once a recompute has run, a second
+    consecutive request must not trigger another one.
+    """
+    zeros = _stats_row(all_time_session_count=0, all_time_distance_km=0)
+    fake_service = FakeStatsService(cached=None, recomputed=zeros, persist_recompute=True)
+    monkeypatch.setattr(stats_routes, "get_stats_service", lambda: fake_service)
+
+    first = client.get("/api/v1/activities/me/stats")
+    second = client.get("/api/v1/activities/me/stats")
+
+    assert first.status_code == status.HTTP_200_OK
+    assert second.status_code == status.HTTP_200_OK
+    assert first.json()["all_time_session_count"] == 0
+    assert second.json()["all_time_session_count"] == 0
     assert fake_service.recompute_calls == ["user-1"]
 
 

--- a/backend/activity-backend/tests/test_user_stats_service.py
+++ b/backend/activity-backend/tests/test_user_stats_service.py
@@ -5,6 +5,12 @@ CLAUDE.md Rule 3. It must carry an explicit ordering and a cap.
 The fake below applies `.eq`, `.not_.in_`, `.order` and `.limit` the way
 PostgREST does, so a missing `.order()` or `.limit()` shows up as the wrong
 rows coming back -- not an un-asserted call on a mock.
+
+`_FakeClient` also backs a `user_stats` table with a plain dict, so
+`recompute_and_upsert` and `get_stats` can be exercised end to end: a
+zero-activity user must come back from a recompute with a persisted row,
+not a deleted one, or every request for that account re-runs the full
+recompute forever.
 """
 
 from typing import Any
@@ -73,11 +79,52 @@ class _Query:
         return _Response(rows)
 
 
-class _FakeClient:
-    def __init__(self, rows):
-        self._rows = rows
+class _UserStatsTable:
+    """The slice of PostgREST that `get_stats`/`_upsert`/`_upsert` use.
 
-    def table(self, _name):
+    Backed by a plain dict keyed on `user_id`, shared with whoever
+    constructed this table, so a row written by one call is visible to the
+    next -- the thing a real Postgres table gives you for free and a
+    stateless fake would hide.
+    """
+
+    def __init__(self, store: dict[str, Any]):
+        self._store = store
+        self._eq_user_id: str | None = None
+        self._pending_upsert: dict[str, Any] | None = None
+
+    def select(self, *_args, **_kwargs):
+        self._pending_upsert = None
+        return self
+
+    def eq(self, column, value):
+        assert column == "user_id"
+        self._eq_user_id = value
+        return self
+
+    def upsert(self, stats, on_conflict="user_id"):
+        assert on_conflict == "user_id"
+        self._pending_upsert = stats
+        return self
+
+    def execute(self):
+        if self._pending_upsert is not None:
+            self._store[self._pending_upsert["user_id"]] = self._pending_upsert
+            return _Response([self._pending_upsert])
+        row = self._store.get(self._eq_user_id)
+        return _Response([row] if row else [])
+
+
+class _FakeClient:
+    def __init__(self, rows, user_stats_store: dict[str, Any] | None = None):
+        self._rows = rows
+        self._user_stats_store: dict[str, Any] = (
+            user_stats_store if user_stats_store is not None else {}
+        )
+
+    def table(self, name):
+        if name == "user_stats":
+            return _UserStatsTable(self._user_stats_store)
         return _Query(self._rows)
 
 
@@ -118,3 +165,55 @@ def test_caps_at_the_configured_ceiling(monkeypatch):
     # Capped *after* ordering newest-first, so a user over the ceiling loses
     # their oldest activities, not an arbitrary slice.
     assert [row["id"] for row in result] == ["newest", "mid"]
+
+
+def test_zero_activities_persists_a_zeros_row_instead_of_deleting():
+    """A recompute that finds nothing must leave a row behind to hit.
+
+    Before the fix, this branch deleted the row and returned `None`, so
+    there was never anything for the next `get_stats` call to find -- a
+    zero-activity account (overwhelmingly new signups, since the route now
+    recomputes on every cache miss) re-ran the full recompute on every
+    single request, forever.
+    """
+    store: dict[str, Any] = {}
+    service = UserStatsService(_FakeClient([], user_stats_store=store))
+
+    result = service.recompute_and_upsert("user-1")
+
+    assert result is not None
+    assert result["all_time_session_count"] == 0
+    assert result["all_time_distance_km"] == 0
+
+
+def test_second_get_stats_after_a_zero_activity_recompute_is_a_cache_hit():
+    """Pins the point of the fix: the row a zero-activity recompute writes
+    is the same row the very next `get_stats` call reads back -- so a
+    caller (the route) never needs to recompute twice in a row.
+    """
+    store: dict[str, Any] = {}
+    service = UserStatsService(_FakeClient([], user_stats_store=store))
+
+    recomputed = service.recompute_and_upsert("user-1")
+    cached = service.get_stats("user-1")
+
+    assert cached == recomputed
+
+
+def test_logs_a_warning_when_the_fetch_lands_exactly_on_the_cap(monkeypatch, caplog):
+    """Truncation at the cap must be greppable, not silent.
+
+    A wrong lifetime total for a heavy user should not ship unnoticed --
+    the `ponytail:` comment on `_MAX_ACTIVITIES_FOR_RECOMPUTE` names the
+    ceiling, and this is what makes hitting it detectable in production.
+    """
+    import logging
+
+    monkeypatch.setattr(UserStatsService, "_MAX_ACTIVITIES_FOR_RECOMPUTE", 3)
+    store: dict[str, Any] = {}
+    service = UserStatsService(_FakeClient(ROWS, user_stats_store=store))
+
+    with caplog.at_level(logging.WARNING, logger="services.user_stats_service"):
+        service.recompute_and_upsert("user-1")
+
+    assert any("user-1" in record.message and "3" in record.message for record in caplog.records)

--- a/backend/activity-backend/tests/test_user_stats_service.py
+++ b/backend/activity-backend/tests/test_user_stats_service.py
@@ -1,0 +1,120 @@
+"""`_fetch_all_activities` now runs on a request path (see test_stats_routes.py),
+not only from a background job, so an unbounded `SELECT` here would violate
+CLAUDE.md Rule 3. It must carry an explicit ordering and a cap.
+
+The fake below applies `.eq`, `.not_.in_`, `.order` and `.limit` the way
+PostgREST does, so a missing `.order()` or `.limit()` shows up as the wrong
+rows coming back -- not an un-asserted call on a mock.
+"""
+
+from typing import Any
+
+from services.user_stats_service import UserStatsService
+
+
+def _activity(activity_id: str, start_time: str, status: str = "ready") -> dict[str, Any]:
+    return {
+        "id": activity_id,
+        "user_id": "user-1",
+        "start_time": start_time,
+        "duration_seconds": 600,
+        "distance_meters": 1000.0,
+        "elevation_gain_meters": 50.0,
+        "processing_status": status,
+    }
+
+
+class _Response:
+    def __init__(self, data):
+        self.data = data
+
+
+class _NotFilter:
+    def __init__(self, query):
+        self._query = query
+
+    def in_(self, column, values):
+        self._query._rows = [r for r in self._query._rows if r.get(column) not in values]
+        return self._query
+
+
+class _Query:
+    def __init__(self, rows):
+        self._rows = list(rows)
+        self._order: tuple[str, bool] | None = None
+        self._limit_n: int | None = None
+
+    def select(self, *_args, **_kwargs):
+        return self
+
+    def eq(self, column, value):
+        self._rows = [r for r in self._rows if r.get(column) == value]
+        return self
+
+    @property
+    def not_(self):
+        return _NotFilter(self)
+
+    def order(self, column, desc=False):
+        self._order = (column, desc)
+        return self
+
+    def limit(self, n):
+        self._limit_n = n
+        return self
+
+    def execute(self):
+        rows = self._rows
+        if self._order is not None:
+            column, desc = self._order
+            rows = sorted(rows, key=lambda r: r[column], reverse=desc)
+        if self._limit_n is not None:
+            rows = rows[: self._limit_n]
+        return _Response(rows)
+
+
+class _FakeClient:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def table(self, _name):
+        return _Query(self._rows)
+
+
+#: Deliberately unordered on input -- the fake hands rows back exactly as
+#: given unless the service asks for an order, which is the wrong order for
+#: "newest first, capped".
+ROWS = [
+    _activity("mid", "2026-08-29T09:00:00Z"),
+    _activity("oldest", "2026-08-28T09:00:00Z"),
+    _activity("newest", "2026-08-30T09:00:00Z"),
+    _activity("pending", "2026-08-31T09:00:00Z", status="pending"),
+]
+
+
+def test_orders_newest_first():
+    service = UserStatsService(_FakeClient(ROWS))
+
+    result = service._fetch_all_activities("user-1")
+
+    assert [row["id"] for row in result] == ["newest", "mid", "oldest"]
+
+
+def test_excludes_in_flight_activities():
+    service = UserStatsService(_FakeClient(ROWS))
+
+    result = service._fetch_all_activities("user-1")
+
+    assert "pending" not in {row["id"] for row in result}
+
+
+def test_caps_at_the_configured_ceiling(monkeypatch):
+    monkeypatch.setattr(UserStatsService, "_MAX_ACTIVITIES_FOR_RECOMPUTE", 2)
+    service = UserStatsService(_FakeClient(ROWS))
+
+    result = service._fetch_all_activities("user-1")
+
+    assert len(result) == 2
+    # Capped *after* ordering newest-first, so a user over the ceiling loses
+    # their oldest activities, not an arbitrary slice.
+    assert [row["id"] for row in result] == ["newest", "mid"]

--- a/frontend/lib/screens/profile/profile_screen.dart
+++ b/frontend/lib/screens/profile/profile_screen.dart
@@ -111,15 +111,14 @@ class _ProfileScreenState extends State<ProfileScreen>
   }
 }
 
-/// Feeds [ProfileTotals] from the signed-in user's activities.
+/// Feeds [ProfileTotals] from the signed-in user's lifetime stats.
 class _OwnTotals extends StatelessWidget {
   const _OwnTotals();
 
   @override
   Widget build(BuildContext context) {
     return Consumer<ActivityProvider>(
-      builder: (context, provider, _) =>
-          ProfileTotals(activities: provider.activities),
+      builder: (context, provider, _) => ProfileTotals(stats: provider.stats),
     );
   }
 }

--- a/frontend/lib/screens/profile/user_profile_screen.dart
+++ b/frontend/lib/screens/profile/user_profile_screen.dart
@@ -207,8 +207,12 @@ class _UserProfileScreenState extends State<UserProfileScreen> {
     // provider's data really is this person's.
     final isOwnProfile =
         widget.userId == null || widget.userId == authUser?.id;
-    final activities =
-        isOwnProfile ? context.watch<ActivityProvider>().activities : null;
+    // ActivityProvider only ever holds the signed-in user's own stats -- no
+    // per-user stats endpoint exists yet (see ProfileHomeContent) -- so a
+    // viewed stranger's totals stay null and render as "unknown" rather than
+    // borrowing the viewer's own numbers.
+    final totalsStats =
+        isOwnProfile ? context.watch<ActivityProvider>().stats : null;
 
     return Scaffold(
       backgroundColor: context.colors.background,
@@ -246,7 +250,7 @@ class _UserProfileScreenState extends State<UserProfileScreen> {
                       ),
                     ),
                     SliverToBoxAdapter(
-                      child: ProfileTotals(activities: activities),
+                      child: ProfileTotals(stats: totalsStats),
                     ),
                     if (_isLocked(isOwnProfile))
                       const SliverToBoxAdapter(child: _PrivateAccountNotice())

--- a/frontend/lib/screens/profile/widgets/profile_totals.dart
+++ b/frontend/lib/screens/profile/widgets/profile_totals.dart
@@ -1,26 +1,32 @@
 import 'package:flutter/material.dart';
 import 'package:snowtrak/core/theme.dart';
-import 'package:snowtrak/models/activity.dart';
+import 'package:snowtrak/models/user_stats.dart';
 import 'package:snowtrak/screens/home/home_stats.dart';
 import 'package:snowtrak/ui/st/st.dart';
 
 /// The lifetime numbers, in the same 4-up strip the design uses on Home.
 ///
-/// [activities] is null when the totals are not knowable — someone else's
-/// profile, whose activities the app cannot read. That renders as `—` rather
-/// than as zeroes, because "0 sessions" claims they have never skied and an
-/// em dash only claims we do not know.
+/// Reads `stats.allTime*` rather than folding over whatever page of
+/// activities happens to be loaded -- `ActivityProvider` only ever holds one
+/// page, so a fold silently stopped growing past the page size (#70).
+///
+/// [stats] is null when the totals are not knowable -- someone else's
+/// profile, whose stats the app cannot read, or the signed-in user's own
+/// stats before the first fetch lands. That renders as `—` rather than as
+/// zeroes, because "0 sessions" claims they have never skied and an em dash
+/// only claims we do not know. A user with genuinely zero activities gets a
+/// non-null [stats] with zero counts, and reads as zeros.
 class ProfileTotals extends StatelessWidget {
-  const ProfileTotals({super.key, required this.activities});
+  const ProfileTotals({super.key, required this.stats});
 
-  final List<Activity>? activities;
+  final UserStats? stats;
 
   @override
   Widget build(BuildContext context) {
-    final activities = this.activities;
+    final stats = this.stats;
 
-    String value(String Function(List<Activity>) format) =>
-        activities == null ? '—' : format(activities);
+    String value(String Function(UserStats) format) =>
+        stats == null ? '—' : format(stats);
 
     return Padding(
       padding: const EdgeInsets.fromLTRB(
@@ -34,37 +40,29 @@ class ProfileTotals extends StatelessWidget {
           children: [
             Expanded(
               child: StStatTile(
-                value: value((a) => '${a.length}'),
+                value: value((s) => '${s.allTimeSessionCount}'),
                 label: 'Sessions',
               ),
             ),
             Expanded(
               child: StStatTile(
-                value: value(
-                  (a) => Imperial.vertical(
-                    a.fold(0.0, (sum, x) => sum + x.elevationGain),
-                  ),
-                ),
+                // Already metres -- no conversion, unlike the two below.
+                value: value((s) => Imperial.vertical(s.allTimeElevGain)),
                 label: 'Vert ft',
               ),
             ),
             Expanded(
               child: StStatTile(
-                value: value(
-                  (a) => Imperial.distance(
-                    a.fold(0.0, (sum, x) => sum + x.distance),
-                  ),
-                ),
+                // allTimeDistanceKm is kilometres; Imperial.distance takes
+                // metres.
+                value: value((s) => Imperial.distance(s.allTimeDistanceKm * 1000)),
                 label: 'Distance',
               ),
             ),
             Expanded(
               child: StStatTile(
-                value: value(
-                  (a) => Imperial.duration(
-                    a.fold(0, (sum, x) => sum + x.duration),
-                  ),
-                ),
+                // allTimeTimeMin is minutes; Imperial.duration takes seconds.
+                value: value((s) => Imperial.duration(s.allTimeTimeMin * 60)),
                 label: 'Time',
               ),
             ),

--- a/frontend/test/screens/profile/widgets/profile_totals_test.dart
+++ b/frontend/test/screens/profile/widgets/profile_totals_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:snowtrak/core/theme.dart';
+import 'package:snowtrak/models/user_stats.dart';
+import 'package:snowtrak/screens/profile/widgets/profile_totals.dart';
+
+/// `ProfileTotals` must show `ActivityProvider.stats.allTime*` -- the
+/// lifetime numbers -- not a fold over whatever page of activities happens
+/// to be in memory (`ActivityProvider._pageSize` is 20; issue #70).
+///
+/// Every fixture below carries activities and stats that disagree, so a
+/// widget that (even accidentally) sums activities instead of reading
+/// `stats` fails these assertions instead of coincidentally passing.
+void main() {
+  UserStats statsFixture({
+    int allTimeSessionCount = 41,
+    double allTimeDistanceKm = 12.5,
+    int allTimeTimeMin = 130,
+    double allTimeElevGain = 900.0,
+  }) {
+    return UserStats(
+      weekStart: DateTime(2026, 8, 31),
+      weeklyDistanceKm: 0,
+      weeklyTimeMin: 0,
+      weeklyElevGain: 0,
+      weeklySessionCount: 0,
+      lastWeekSessionCount: 0,
+      yearlyDistanceKm: 0,
+      yearlyTimeMin: 0,
+      yearlyElevGain: 0,
+      yearlySessionCount: 0,
+      allTimeDistanceKm: allTimeDistanceKm,
+      allTimeTimeMin: allTimeTimeMin,
+      allTimeElevGain: allTimeElevGain,
+      allTimeSessionCount: allTimeSessionCount,
+      activityDays: const {},
+      bestEfforts: const [],
+      currentStreak: 0,
+      longestStreak: 0,
+    );
+  }
+
+  Future<void> pump(WidgetTester tester, UserStats? stats) {
+    return tester.pumpWidget(
+      MaterialApp(
+        theme: SnowtrakTheme.lightTheme,
+        home: Scaffold(body: ProfileTotals(stats: stats)),
+      ),
+    );
+  }
+
+  testWidgets('renders lifetime sessions from stats, not a page count',
+      (tester) async {
+    // 41 lifetime sessions is well past the 20-activity page the old widget
+    // folded over -- a page-based reading could never show this number.
+    await pump(tester, statsFixture(allTimeSessionCount: 41));
+
+    expect(find.text('41'), findsOneWidget);
+  });
+
+  testWidgets('converts allTimeDistanceKm (km) to the imperial display (miles)',
+      (tester) async {
+    // 12.5 km == 12_500 m == 7.767... mi. A units bug that treats km as
+    // metres would instead show "12.5 mi" -- both numbers below are
+    // asserted so that mistake cannot pass by coincidence.
+    await pump(tester, statsFixture(allTimeDistanceKm: 12.5));
+
+    expect(find.text('7.8 mi'), findsOneWidget);
+    expect(find.text('12.5 mi'), findsNothing);
+  });
+
+  testWidgets('converts allTimeTimeMin (minutes) to the imperial display (h/m)',
+      (tester) async {
+    // 130 min == 2h 10m == 7800 s. A units bug that treats minutes as
+    // seconds would instead show "2m".
+    await pump(tester, statsFixture(allTimeTimeMin: 130));
+
+    expect(find.text('2h 10m'), findsOneWidget);
+    expect(find.text('2m'), findsNothing);
+  });
+
+  testWidgets('renders allTimeElevGain (already metres) unconverted',
+      (tester) async {
+    await pump(tester, statsFixture(allTimeElevGain: 900.0));
+
+    expect(find.text('2,953 ft'), findsOneWidget);
+  });
+
+  testWidgets('renders em dash for null stats -- unknown, not zero',
+      (tester) async {
+    await pump(tester, null);
+
+    expect(find.text('—'), findsNWidgets(4));
+    expect(find.text('0'), findsNothing);
+  });
+}

--- a/frontend/test/widgets/other_profile_layout_test.dart
+++ b/frontend/test/widgets/other_profile_layout_test.dart
@@ -27,7 +27,7 @@ void main() {
           ),
           body: ListView(
             children: const [
-              ProfileTotals(activities: null),
+              ProfileTotals(stats: null),
               ProfileHomeContent(isOwnProfile: false),
             ],
           ),


### PR DESCRIPTION
## Description

The lifetime totals strip on My Profile summed **one page** of activities and
called the result a lifetime. `ProfileTotals` folded `provider.activities`,
which `ActivityProvider` caps at `_pageSize = 20`, so past twenty activities
Sessions stuck at 20 and Vert, Distance and Time undercounted to match —
silently, with no error.

The correct source already existed on the same screen: `ActivityProvider.stats`
(`UserStats.allTime*`), which `ProfileHomeContent` was already reading
twenty-five lines above the broken widget.

Fixes #70.

> [!IMPORTANT]
> **Swapping the widget alone would have made this worse**, which is why the
> backend changes are here too. `user_stats` held **12 rows for 41 users** with
> a newest `updated_at` of `2026-06-30`, and `GET /me/stats` answered a cache
> miss with zeros on a stated assumption that is false — *"No cached row means
> the user has no activities yet"*. A missing row means nobody has written one;
> 29 accounts had activities and no row, because seed data was inserted
> straight into the table and `recompute_and_upsert` only fires on API writes.
> The naive fix would have shown `0 Sessions · 0 ft · 0 mi · 0m` to most users,
> which is worse than a wrong number — `ProfileTotals` says why in its own
> docstring: *"0 sessions" claims they have never skied and an em dash only
> claims we do not know.*

**What changed**

- `GET /me/stats` recomputes on a cache miss instead of asserting zeros, and
  returns zeros only when the recompute genuinely finds no activities. This
  self-heals the 29 stale accounts on their next profile open — no backfill
  script needed.
- An empty recompute now **persists** a zeros row rather than deleting it, so
  a zero-activity user is a cache hit on their second request instead of
  re-running a full recompute on every single profile view, forever.
- `_fetch_all_activities` gained an explicit ordering and a 5,000-row cap
  (CLAUDE.md Rule 3, now that it runs on the request path), plus a
  `logger.warning` when a fetch lands exactly on that cap — a silently
  truncated lifetime total is otherwise undetectable in production.
- `ProfileTotals` reads `stats.allTime*`, converting km→m and min→s for the
  `Imperial` helpers, which take metres and seconds.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Docs or CI/infra update

## Testing

- [x] Local testing
- [x] Manual verification against live data
- [ ] Ran full CI locally

```
backend/activity-backend   86 passed
frontend                   91 passed   (dart analyze: no issues)
ruff check                 clean on touched files
```

Every new test was confirmed **failing before the change** — `0 == 123` on the
recompute, wrong ordering on the bound, `No named parameter 'stats'` on the
widget. The unit-conversion tests assert the *wrong* values are absent
(`findsNothing` on `12.5 mi`, `2m`), so a 1000x or 60x slip fails them rather
than rendering something plausible.

Checked by hand against a real account — 17 activities, 1.53 m gain,
1981.52 m, 316 s — which renders `17 · 5 ft · 1.2 mi · 5m`.

## Checklist

- [x] I have self-reviewed my code
- [x] I have added tests
- [ ] I have updated docs (no doc surface changed)
- [x] My commit messages follow the Conventional Commits format
- [x] No uncommitted secrets or large files in this PR
- [ ] CI passes — see checks below

## Not in scope

- #71 (the same strip showing another user's activities) was a separate defect,
  already fixed on `develop` by `fae381e` and confirmed on a current build.
- Someone else's profile still renders `—`. That is unchanged behaviour, not a
  regression: `user_profile_screen.dart` already passed `activities: null` for
  non-own profiles. A per-user public stats endpoint would be a feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015npbKaSNS6MbCJi4Khs54M
