### PR TITLE
fix(release): tie the version to the tag, and keep rc off production

### DIFF
--- a/.github/workflows/deploy-backend-vps.yml
+++ b/.github/workflows/deploy-backend-vps.yml
@@ -64,9 +64,18 @@ jobs:
             exit 0
           fi
 
-          # Production takes release tags only. Staging additionally takes a raw
-          # commit SHA so a develop commit can be tested without cutting a tag.
-          if [[ "$REF" =~ ^v ]]; then
+          # Production takes final release tags only -- the same pattern
+          # flutter-release.yml matches. A bare `^v` also matched v0.0.2-rc1,
+          # which is how a release candidate came to serve production for 11
+          # days. Staging still takes any v* tag, and a raw commit SHA, so a
+          # candidate can be exercised before it is promoted.
+          if [[ "$REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            image_tag="$REF"
+          elif [[ "$REF" =~ ^v ]]; then
+            if [ "$DEPLOY_ENV" = "production" ]; then
+              echo "::error::production deploys a final tag (v1.2.3), not a pre-release: '$REF'." >&2
+              exit 1
+            fi
             image_tag="$REF"
           elif [[ "$REF" =~ ^[0-9a-f]{40}$ ]]; then
             if [ "$DEPLOY_ENV" = "production" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.0.8] - 2026-09-06
+
+_The git tag is now the version. Cut `v0.0.8` and the App Store sees `0.0.8`;
+`pubspec.yaml` is no longer bumped by hand. Production refuses a `-rc` tag from
+here on, so promote a candidate by cutting the final tag._
+
+### Changed
+
+- **Breaking:** deploy only a final `v1.2.3` tag to the production backend, where any `v*` tag was accepted and a release candidate served production for 11 days ([#75](https://github.com/Syntraksoftware/Snowtrak/pull/75))
+- Take the App Store marketing version from the release tag rather than `pubspec.yaml`, which had read `1.0.0` since May ([#75](https://github.com/Syntraksoftware/Snowtrak/pull/75))
+
+### Fixed
+
+- Deliver an uploaded build to testers without a manual click — every build stalled on Missing Compliance because `Info.plist` answered no export-compliance question ([#75](https://github.com/Syntraksoftware/Snowtrak/pull/75))
+
+[0.0.8]: https://github.com/Syntraksoftware/Snowtrak/releases/tag/v0.0.8
+
 ## [0.0.7] - 2026-09-06
 
 _A merge no longer reaches testers. Ask for a TestFlight build with

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -47,7 +47,7 @@ are still current. Each is spelled out in
 | Landing code | PR only. No direct pushes to `main` or `develop`. No force-push. |
 | Merging | 8 checks must pass. No approval required — you may merge your own PR. |
 | Creating a `v*` tag | Repository admins only. |
-| Production backend deploy | `v*` tags only. Pauses for a reviewer. |
+| Production backend deploy | Final `v1.2.3` tags only, never `-rc`. Pauses for a reviewer. |
 | Staging backend deploy | A `v*` tag, or a 40-character commit SHA. No reviewer. |
 | App Store upload | Final versions only (`v1.2.3`, not `v1.2.3-rc1`). Pauses for a reviewer. |
 | TestFlight | Manual. Actions -> iOS Staging -> Run workflow, any branch. |
@@ -96,6 +96,9 @@ The tag starts two things at once:
   (~3–5 min). If Trivy finds a fixable CRITICAL/HIGH, nothing is published.
 - **iOS Production Release** builds the app, then **waits for your approval**
   before uploading to Apple.
+
+The tag is also the version number: `v1.2.3` ships to Apple as `1.2.3`. There
+is no `pubspec.yaml` bump to remember, and nothing else to keep in step.
 
 ### 4. Approve the App Store upload
 
@@ -187,8 +190,8 @@ Three things to know:
   data one — a like made on staging is a real like.
 - A feature branch cannot be deployed. Images are published only for `main`,
   `develop` and `v*` tags, so merge to `develop` first and deploy its SHA.
-- An `-rc` tag is safe. It deploys to staging but does **not** reach the App
-  Store, because the iOS release only matches final version numbers.
+- An `-rc` tag is safe. It deploys to staging but reaches neither production
+  nor the App Store — both gates match final version numbers only.
 
 ## Rolling back
 
@@ -217,7 +220,7 @@ Takes the same ~3–5 min as a deploy.
 | Symptom | Cause | Fix |
 |---|---|---|
 | Deploy fails pulling, `denied` | Packages are private | Make them public — see the top of this file |
-| Deploy rejects your ref | Production takes `v*` tags only; a raw SHA is staging-only | Deploy a tag |
+| Deploy rejects your ref | Production takes a final `v1.2.3` tag; `-rc` tags and raw SHAs are staging-only | Cut a final tag, or deploy to staging |
 | `could not resolve ...:v1.2.3` | Docker Images did not publish for that tag | Check the Docker Images run for that tag; a failed Trivy gate blocks publishing |
 | Tag push rejected | You are not a repository admin | Ask an admin to cut the tag |
 | PR will not merge | One of the 8 required checks has not passed | Check the PR's checks; `Build, Scan, Push` and `Validate iOS` do not block |

--- a/docs/ios_release_pipeline.md
+++ b/docs/ios_release_pipeline.md
@@ -88,12 +88,35 @@ rm ~/Desktop/dist.p12
 If the new certificate has a different SHA-1, update `signingCertificate` in
 `ExportOptions.plist` — `security find-identity -v -p codesigning` prints it.
 
-## Build numbers
+## Version numbers
 
-`Fastfile` asks App Store Connect for the highest build number already uploaded
-for the current marketing version and adds one, so `CFBundleVersion` never
-collides. The marketing version (`CFBundleShortVersionString`) still comes from
-`pubspec.yaml` and is bumped by hand.
+Two numbers, two sources.
+
+`CFBundleVersion` — the build number. `Fastfile` asks App Store Connect for the
+highest one already uploaded for the current marketing version and adds one, so
+it never collides.
+
+`CFBundleShortVersionString` — the marketing version. The **production lane
+takes it from the git tag**: `v1.2.3` builds `1.2.3`, via `--build-name`.
+`pubspec.yaml` has read `1.0.0` since May and is no longer the source of truth
+for a release; nobody has to remember to bump it.
+
+The tag only wins when it looks like one. A `workflow_dispatch` run, a local
+`bundle exec fastlane production`, or the staging lane all leave
+`GITHUB_REF_NAME` holding a branch — no `--build-name` is passed and `pubspec`
+supplies the version, as before. A `-rc` tag is not matched either, and cannot
+reach the App Store anyway.
+
+## Export compliance
+
+`Info.plist` declares `ITSAppUsesNonExemptEncryption = false`, so an upload
+answers Apple's export question by itself. Without it every build sat on
+**Missing Compliance** in TestFlight until somebody clicked through the web UI,
+which no CI run can do.
+
+`false` holds while the only cryptography in the app is platform HTTPS/TLS,
+which is exempt. Bundle a cipher, ship your own key exchange, or do anything
+beyond ATS, and the key has to be revisited before the next upload.
 
 ## Running it locally
 

--- a/frontend/ios/Runner/Info.plist
+++ b/frontend/ios/Runner/Info.plist
@@ -22,6 +22,13 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<!-- Answers Apple's export-compliance question at upload time instead of
+	     leaving every build stuck on Missing Compliance until a human clicks
+	     through App Store Connect. false is correct while the only crypto here
+	     is platform HTTPS/TLS, which is exempt. Ship a cipher of our own and
+	     this key has to be revisited. -->
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/frontend/ios/fastlane/Fastfile
+++ b/frontend/ios/fastlane/Fastfile
@@ -94,7 +94,17 @@ platform :ios do
     end
   end
 
-  def flutter_build_ipa(target:, app_env:, map_features_enabled:, build_number:)
+  # The version Apple shows comes from the git tag, not pubspec.yaml -- that
+  # line has read 1.0.0 since May, so every release so far was labelled 1.0.0
+  # and two of them were distinguishable only by build number. Returns nil for
+  # a workflow_dispatch run, where GITHUB_REF_NAME holds a branch: no
+  # --build-name is passed and pubspec supplies the number, as before.
+  def release_build_name
+    ref = ENV["GITHUB_REF_NAME"].to_s
+    ref =~ /\Av(\d+\.\d+\.\d+)\z/ ? Regexp.last_match(1) : nil
+  end
+
+  def flutter_build_ipa(target:, app_env:, map_features_enabled:, build_number:, build_name: nil)
     started_at = Time.now
     Dir.chdir(flutter_root) do
       sh([
@@ -105,6 +115,7 @@ platform :ios do
         target,
         "--build-number",
         build_number.to_s,
+        *(build_name ? ["--build-name", build_name] : []),
         "--export-options-plist",
         File.join(flutter_root, "ios/ExportOptions.plist"),
         *flutter_define_args(app_env: app_env, map_features_enabled: map_features_enabled),
@@ -210,6 +221,7 @@ platform :ios do
       app_env: "prod",
       map_features_enabled: true,
       build_number: next_build_number(api_key),
+      build_name: release_build_name,
     )
     deliver(
       api_key: api_key,


### PR DESCRIPTION
Three defects on the release path, all with the same shape: the number on the
artifact is not the number you cut.

## What changed

**Export compliance (#61).** `Info.plist` now declares
`ITSAppUsesNonExemptEncryption = false`. Without it App Store Connect asked
per build, every upload sat on **Missing Compliance**, and a tester could not
install until somebody clicked through the web UI — which no CI run can do.
`false` is correct while the only cryptography here is platform HTTPS/TLS; the
comment beside the key names the condition under which it has to be revisited.

**Version from the tag (#62).** `pubspec.yaml` has read `1.0.0` since
2026-05-16 and nothing wrote the release tag anywhere the app could see it, so
eight builds shipped as `1.0.0` and were distinguishable only by build number.
The production lane now derives `--build-name` from `GITHUB_REF_NAME` when it
looks like a final tag. Deriving beats bumping: there is no second place to
keep in step and no step to forget. A `workflow_dispatch` run, a local
`bundle exec fastlane production` and the staging lane all hold a branch there,
get no `--build-name`, and fall through to `pubspec` exactly as before.

**Production deploy gate (#68).** The gate matched a bare `^v`, which accepted
`v0.0.2-rc1` and left a release candidate serving production for 11 days. It
now matches the same `v[0-9]+.[0-9]+.[0-9]+` that `flutter-release.yml` already
enforced. Staging still takes any `v*` tag and a raw SHA, because exercising a
candidate is what candidates are for.

## Verification

| Ref | production | staging |
|---|---|---|
| `v0.0.3` | accepted | accepted |
| `v0.0.2-rc1` | **rejected** | accepted |
| 40-char SHA | rejected (unchanged) | accepted |
| `develop` | rejected (unchanged) | rejected |

`--build-name`: `v1.2.3` → `1.2.3`; `v0.0.2-rc1`, `develop` and unset → no
flag, `pubspec` supplies it.

`plutil -lint` on the plist, `ruby -c` on the Fastfile, `ruby -ryaml` on the
workflow: all pass. No Dart or Python touched.

## Not in this PR

- Answering compliance by hand for build **1.0.0 (9)**, already uploaded. The
  key only covers uploads after it.
- `#67` — `staging-map.syntrak.io` still has no DNS A record. Cloudflare, not
  code.
- Production reporting `"environment":"development"`. `ENVIRONMENT` is unset in
  the `.env` on the droplet and `config.py` defaults to `development`; that is
  a box change, not a repo one.

Closes #61
Closes #62
Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Drf1a1Fb9yDPrjimoKQD1J