### PR TITLE
fix(ios): decode the distribution certificate in the release workflow too

### DIFF
--- a/.github/workflows/flutter-release.yml
+++ b/.github/workflows/flutter-release.yml
@@ -2,6 +2,12 @@ name: iOS Production Release
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to build, without the v (1.2.3). Only for re-running a release whose tag run failed; leave empty and pubspec supplies it.'
+        required: false
+        default: ''
+        type: string
   push:
     tags:
       # Final versions only. 'v*' also matched pre-release tags such as
@@ -42,6 +48,21 @@ jobs:
         run: |
           echo "$ASC_KEY_BASE64" | base64 --decode > /tmp/AuthKey.p8
 
+      - name: Decode distribution certificate
+        # The App Store Connect API can hand back the provisioning profile, but
+        # never a private key -- so the .p12 has to travel as a secret. fastlane
+        # imports it into the throwaway keychain setup_ci creates. Both lanes
+        # need this; for a while only the TestFlight workflow had it, and every
+        # production run died on "Distribution certificate not found".
+        env:
+          IOS_DIST_CERT_BASE64: ${{ secrets.IOS_DIST_CERT_BASE64 }}
+        run: |
+          if [ -z "$IOS_DIST_CERT_BASE64" ]; then
+            echo "ERROR: IOS_DIST_CERT_BASE64 is not set. See docs/ios_release_pipeline.md." >&2
+            exit 1
+          fi
+          echo "$IOS_DIST_CERT_BASE64" | base64 --decode > /tmp/dist.p12
+
       - name: Create placeholder MapTiler asset
         # frontend/pubspec.yaml declares .env.local.json as an asset, but the file
         # is gitignored (it holds a real MapTiler key), so CI never has it and the
@@ -61,7 +82,10 @@ jobs:
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
           ASC_KEY_PATH: /tmp/AuthKey.p8
           APP_IDENTIFIER: ${{ secrets.APP_IDENTIFIER }}
-          PROV_PROFILE_NAME: ${{ secrets.PROV_PROFILE_NAME }}
+          IOS_DIST_CERT_PATH: /tmp/dist.p12
+          IOS_DIST_CERT_PASSWORD: ${{ secrets.IOS_DIST_CERT_PASSWORD }}
+          # Empty on a tag push, where the tag itself is the version.
+          RELEASE_VERSION: ${{ inputs.version }}
           # Baked into the binary via --dart-define by the Fastfile. Without it the
           # shipped build falls back to keyless open tile sources.
           MAPTILER_API_KEY: ${{ secrets.MAPTILER_API_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ frontend/test/failures/
 
 # per-machine Claude Code settings; .claude/settings.json is the shared one
 .claude/settings.local.json
+
+# macOS Finder metadata; committed once by accident.
+.DS_Store

--- a/docs/ios_release_pipeline.md
+++ b/docs/ios_release_pipeline.md
@@ -60,6 +60,11 @@ contain.
 | `MAPTILER_API_KEY` | baked in via `--dart-define`; without it the build falls back to keyless tiles |
 | `FASTLANE_APPLE_ID` | read by `Appfile`, kept out of this public repo |
 
+Both workflows need all of these. `ios-testflight.yml` and
+`flutter-release.yml` run the same signing helper, so a secret wired into one
+and not the other fails at `import_certificate` with
+`Distribution certificate not found at /tmp/dist.p12`.
+
 The provisioning profile is **not** a secret. `fastlane` downloads it at build
 time through the API key, so it cannot go stale in a secret nobody looks at.
 The private key is the one thing Apple's API will never hand back, which is
@@ -117,6 +122,29 @@ which no CI run can do.
 `false` holds while the only cryptography in the app is platform HTTPS/TLS,
 which is exempt. Bundle a cipher, ship your own key exchange, or do anything
 beyond ATS, and the key has to be revisited before the next upload.
+
+## Re-running a release that failed
+
+A tag push runs the workflow file **as it stood when the tag was cut**. Fixing
+the file on `main` afterwards does nothing for the run that already failed, and
+re-running the job replays the same broken copy.
+
+The way back is a dispatch, which reads the current file:
+
+```
+Actions -> iOS Production Release -> Run workflow
+  branch:  main
+  version: 0.0.8     <- the tag's version, without the v
+```
+
+`version` exists only for this. A dispatch has a branch in `GITHUB_REF_NAME`,
+not a tag, so without it the build falls back to `pubspec.yaml` and ships the
+wrong marketing version. Leave it empty on any run where that fallback is what
+you want.
+
+Do not move the tag instead. `v0.0.8` names the commit whose images production
+is running; re-pointing it would rebuild those images under new digests and
+leave the tag describing something the box never ran.
 
 ## Running it locally
 

--- a/frontend/ios/fastlane/Fastfile
+++ b/frontend/ios/fastlane/Fastfile
@@ -100,6 +100,14 @@ platform :ios do
   # a workflow_dispatch run, where GITHUB_REF_NAME holds a branch: no
   # --build-name is passed and pubspec supplies the number, as before.
   def release_build_name
+    # A tag push runs the workflow file as it stood when the tag was cut, so
+    # fixing that file does not fix a run that already failed. Re-running it as
+    # a dispatch is the way back, and a dispatch has a branch in
+    # GITHUB_REF_NAME -- hence the override, which keeps the re-run on the
+    # version the tag named instead of falling back to pubspec.
+    explicit = ENV["RELEASE_VERSION"].to_s
+    return explicit if explicit =~ /\A\d+\.\d+\.\d+\z/
+
     ref = ENV["GITHUB_REF_NAME"].to_s
     ref =~ /\Av(\d+\.\d+\.\d+)\z/ ? Regexp.last_match(1) : nil
   end


### PR DESCRIPTION
`v0.0.8` shipped to production. The App Store half of it never got past
signing:

```
[!] Distribution certificate not found at /tmp/dist.p12
fastlane finished with errors
```

## Cause

`setup_ci_signing` reads `/tmp/dist.p12` in **both** lanes. Only
`ios-testflight.yml` ever wrote it. `flutter-release.yml` decodes the ASC key
and nothing else, so `import_certificate` had no file to import.

The staging path was the one under a microscope when that helper was added
(#72), and the release path was not exercised until this tag. Its env still
carried `PROV_PROFILE_NAME`, which nothing has read since the profile started
being fetched through the API key — removed here with the rest.

## The re-run path

Fixing the workflow does not fix the failed run: a tag push executes the
workflow file **as it stood when the tag was cut**, and re-running the job
replays the same broken copy.

A dispatch reads the current file, but carries a branch in `GITHUB_REF_NAME` —
so `v0.0.8` would have gone to Apple labelled `1.0.0`, straight back into the
problem #62 just fixed. `workflow_dispatch` therefore takes an optional
`version`, which wins over the ref when it parses as one.

| `RELEASE_VERSION` | `GITHUB_REF_NAME` | version built |
|---|---|---|
| `0.0.8` | `main` | `0.0.8` |
| empty | `v1.2.3` | `1.2.3` |
| empty | `develop` | pubspec |
| `1.2.3` | `v9.9.9` | `1.2.3` |
| `abc` | `v0.0.8` | `0.0.8` |
| empty | empty | pubspec |

## Why not move the tag

`v0.0.8` names the commit whose images production is running right now.
Re-pointing it rebuilds those images under new digests and leaves the tag
describing something the box never ran. A tag that lies is worse than a
workflow input.

## After this merges

```
Actions -> iOS Production Release -> Run workflow
  branch:  main
  version: 0.0.8
```

`.gitignore` gains `.DS_Store`; one had been sitting untracked in `backend/`.

`ruby -c` on the Fastfile, `ruby -ryaml` on the workflow, and the six-case
table above all pass. The version precedence is the only new logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Drf1a1Fb9yDPrjimoKQD1J


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Improvements**
  - Added a manual release rerun option for recovering failed tagged releases while preserving the intended app version.
  - Improved signing-certificate validation during release builds to provide clearer failure handling.

- **Documentation**
  - Added guidance for rerunning failed releases, version inputs, tag handling, and required signing configuration.
  - Clarified that release tags continue to identify the exact source used for production builds.

- **Maintenance**
  - Added protection against committing macOS metadata files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->