### PR TITLE
fix(ios): stop deliver running precheck after the upload

### DIFF
--- a/docs/ios_release_pipeline.md
+++ b/docs/ios_release_pipeline.md
@@ -206,3 +206,14 @@ previous run's IPA on disk. That once shipped a three-month-old binary to
 Apple. `Fastfile` now compares the IPA's mtime against the start of the build
 and fails loudly instead. If you see `Stale IPA at ...`, the real error is
 further up the log — it is an export failure, not a packaging one.
+
+A red run does not always mean nothing reached Apple. `deliver` uploads first
+and validates after, so a failure late in that action can sit above a
+successful upload. Search the log for `Successfully uploaded package` before
+assuming a re-run is needed; uploading the same build number twice is rejected
+by App Store Connect, so the re-run would fail for a second, unrelated reason.
+
+This bit once: `deliver` ran `precheck`, which cannot read in-app purchases
+with an API key, and failed the build after the binary had landed. Precheck is
+off now — nothing here submits for review or sends metadata, so it had nothing
+left to validate.

--- a/frontend/ios/fastlane/Fastfile
+++ b/frontend/ios/fastlane/Fastfile
@@ -238,6 +238,12 @@ platform :ios do
       skip_metadata: true,
       skip_screenshots: true,
       submit_for_review: false,
+      # Nothing is submitted here and no metadata is sent, so precheck has
+      # nothing left to validate -- but deliver runs it anyway, and it cannot
+      # read in-app purchases with an API key, only with an Apple ID login.
+      # That failed the build *after* the binary had already reached Apple,
+      # which is the worst place to fail: a red run over a successful upload.
+      run_precheck_before_submit: false,
       force: true
     )
   end


### PR DESCRIPTION
## The upload worked. The run went red anyway.

Run [34027403516](https://github.com/Syntraksoftware/Snowtrak/actions/runs/34027403516):

```
10:33:53  Successfully uploaded package to App Store Connect.
10:33:53  [!] Precheck cannot check In-app purchases with the App Store
              Connect API Key (yet). Exclude In-app purchases from precheck,
              disable the precheck step in your build step, or use Apple ID login
10:33:53  fastlane finished with errors
```

`deliver` uploads first and validates after. The binary was at Apple before
this fired.

## Fix

`precheck` validates App Store metadata ahead of a submission. This lane sends
`skip_metadata: true` and `submit_for_review: false`, so it had nothing to
validate — it ran only because `deliver` runs it by default. Now
`run_precheck_before_submit: false`.

## The three things this release was meant to prove

All three did, before precheck killed the run:

| Checkpoint | Log |
|---|---|
| PR #77's certificate decode | `Step: import_certificate` → `Installing provisioning profile...` |
| #62, the tag reaching the app | `flutter build ipa ... --build-number 10 --build-name 0.0.8` |
| The binary reaching Apple | `Successfully uploaded package to App Store Connect` |

`--build-name 0.0.8` is the first time this app has been built with a version
that was not `1.0.0`.

## Not fixed here

`next_build_number` asks for the latest build of the *live* version, got `9`
for `1.0.0`, and so started `0.0.8` at build 10 rather than 1. Build numbers
only have to rise within a version, so overshooting costs nothing; teaching
that helper which version is being built is a larger change than the bug
deserves. Worth an issue if the gap ever gets confusing.

## Do not re-run the failed release

Build `0.0.8 (10)` is already uploaded. A re-run would be rejected for a
duplicate build number — a second, unrelated failure that reads like the first
one never got fixed. This PR is for the *next* release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Drf1a1Fb9yDPrjimoKQD1J
